### PR TITLE
chore(ci): перевести Dependabot на bun

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,12 @@
 version: 2
 updates:
   # Server
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/server"
     schedule:
       interval: "weekly"
   # UI
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/UI"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Что сделано
- В `.github/dependabot.yml` для `server` и `UI` заменен `package-ecosystem` с `npm` на `bun`.
- Расписание обновлений оставлено без изменений: `weekly`.

## Зачем
- Проект использует Bun и lock-файлы `bun.lock`, поэтому Dependabot должен работать через `bun`-экосистему.