### PR TITLE
Исправить расчёт суммы купонов за год

### DIFF
--- a/server/src/common/getMoexData.test.ts
+++ b/server/src/common/getMoexData.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import moment from "moment"
+import { calculateCouponsYieldForYear } from "./getMoexData"
+
+test("calculateCouponsYieldForYear sums only coupons within the next 12 months", () => {
+	const nowDate = moment("2026-04-14")
+
+	const coupons = [
+		{ date: moment("2026-04-13"), value: 10 },
+		{ date: moment("2026-06-01"), value: 15 },
+		{ date: moment("2027-04-14"), value: 20 },
+		{ date: moment("2027-04-15"), value: 25 },
+	] as const
+
+	expect(calculateCouponsYieldForYear([...coupons], nowDate)).toBe(35)
+})

--- a/server/src/common/getMoexData.ts
+++ b/server/src/common/getMoexData.ts
@@ -33,6 +33,22 @@ async function moexGet(url: string) {
   throw lastError
 }
 
+export function calculateCouponsYieldForYear(coupons: MoexCoupon[], nowDate = moment()) {
+  const oneYearLater = nowDate.clone().add(1, "year")
+
+  return coupons.reduce<number>((acc, coupon) => {
+    const couponDate = coupon?.date
+
+    if (!couponDate?.isValid()) {
+      return acc
+    }
+
+    return couponDate.isAfter(nowDate) && couponDate.isSameOrBefore(oneYearLater)
+      ? acc + coupon.value
+      : acc
+  }, 0)
+}
+
 export function getMoexData(tickers: string[]): Promise<MoexResults> {
   return new Promise((resolve, reject) => {
     const cache = Cache({ ttl: 60 * 60 * 4 })
@@ -125,7 +141,7 @@ export async function buildDataFromMoex(marketData, tickers: string[]) {
       }
 
       const nowDate = moment()
-      result[secId].couponsYield = result[secId].coupons.reduce<number>((acc, coupon) => (coupon?.date?.isAfter(nowDate) ? acc + coupon?.value : acc), 0)
+      result[secId].couponsYield = calculateCouponsYieldForYear(result[secId].coupons, nowDate)
 
       result[secId].trades = await cache.get(`moexData.${secId}.trades`)
 


### PR DESCRIPTION
## Что сделано
- исправлен расчёт поля `∑ Купон за год`: теперь учитываются только купоны на ближайшие 12 месяцев, а не все будущие выплаты до погашения
- вынесена отдельная функция расчёта годовой суммы купонов
- добавлен тест на граничные случаи для окна в 12 месяцев

## Проверка
- `bun test src/common/getMoexData.test.ts`
- `bun run build`

## Связанный issue
- closes #98