### PR TITLE
feat: доработать аналитику подобранного портфеля

### DIFF
--- a/UI/env.d.ts
+++ b/UI/env.d.ts
@@ -2,7 +2,7 @@
 
 interface YandexMetrikaFunction {
 	(id: string, action: string, options?: Record<string, unknown>): void
-	a?: IArguments[]
+	a?: unknown[][]
 	l?: number
 }
 

--- a/UI/package.json
+++ b/UI/package.json
@@ -6,6 +6,7 @@
     "dev": "vite",
     "build": "run-p type-check build-only",
     "preview": "vite preview",
+    "test": "bun test src/utils/portfolio.test.ts",
     "build-only": "vite build",
     "type-check": "vue-tsc --noEmit -p tsconfig.app.json --composite false",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",

--- a/UI/src/components.d.ts
+++ b/UI/src/components.d.ts
@@ -19,6 +19,8 @@ declare module 'vue' {
     LinksToExchange: typeof import('./components/UI/LinksToExchange.vue')['default']
     LiquidityArrow: typeof import('./components/UI/LiquidityArrow.vue')['default']
     LoadingOverlay: typeof import('./components/UI/LoadingOverlay.vue')['default']
+    PortfolioCouponChart: typeof import('./components/PortfolioCouponChart.vue')['default']
+    PortfolioSectorChart: typeof import('./components/PortfolioSectorChart.vue')['default']
     PortfolioStats: typeof import('./components/PortfolioStats.vue')['default']
     PortfolioTable: typeof import('./components/PortfolioTable.vue')['default']
     RiskStars: typeof import('./components/UI/RiskStars.vue')['default']

--- a/UI/src/components/BondsTable.vue
+++ b/UI/src/components/BondsTable.vue
@@ -179,7 +179,7 @@ import IssueKindCollations from "@/data/collations/IssueKindCollations"
 import ExchangeCollation from "@/data/collations/ExchangeCollation"
 import CurrencyCollation from "@/data/collations/CurrencyCollation"
 import { portfolioStore } from "@/data/portfolioStore"
-import type { sortState } from "@/data/Types/SortState"
+import type { sortState as SortState } from "@/data/Types/SortState"
 import type { CombinedBondsResponse } from "@/data/Interfaces/CombinedBondsResponse"
 import BondFlags from "@/components/UI/BondFlags.vue"
 import LiquidityArrow from "@/components/UI/LiquidityArrow.vue"
@@ -204,7 +204,7 @@ const props = defineProps({
 		required: true
 	},
 	sortState: {
-		type: Object as PropType<sortState>,
+		type: Object as PropType<SortState>,
 		required: true
 	},
 	showAddButton: {
@@ -214,7 +214,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits<{
-	(e: "update:sortState", value: sortState): void
+	(e: "update:sortState", value: SortState): void
 	(e: "update:page", value: number): void
 	(e: "update:page-size", value: number): void
 }>()

--- a/UI/src/components/PortfolioCouponChart.vue
+++ b/UI/src/components/PortfolioCouponChart.vue
@@ -1,0 +1,54 @@
+<template>
+	<div class="space-y-4 rounded-box border border-base-300 bg-base-100 p-4">
+		<div class="flex items-center justify-between gap-3">
+			<h3 class="text-base font-semibold text-base-content">Купоны на ближайший год</h3>
+			<span class="text-xs text-base-content/60">Сумма по месяцам, RUB</span>
+		</div>
+
+		<div v-if="items.length < 1" class="rounded-box bg-base-200 px-4 py-6 text-sm text-base-content/70">
+			Нет данных по купонам.
+		</div>
+
+		<div v-else class="grid grid-cols-12 gap-2">
+			<div
+				v-for="item in items"
+				:key="item.month"
+				class="flex min-w-0 flex-col items-center gap-2"
+			>
+				<div class="flex h-36 w-full items-end rounded-box bg-base-200 px-1 py-2">
+					<div
+						class="w-full rounded-t-md bg-primary transition-all"
+						:style="{ height: `${getBarHeight(item.amountRub)}%` }"
+					></div>
+				</div>
+				<div class="text-center text-[11px] leading-tight text-base-content/70">{{ shortLabel(item.label) }}</div>
+				<div class="text-center text-[11px] font-medium text-base-content">{{ formatMoney(item.amountRub) }}</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script lang="ts" setup>
+import { computed, type PropType } from "vue"
+import type { PortfolioCouponScheduleItem } from "@/data/Interfaces/PortfolioMetrics"
+import { formatMoney } from "@/utils/format"
+
+const props = defineProps({
+	items: {
+		type: Array as PropType<PortfolioCouponScheduleItem[]>,
+		default: () => []
+	}
+})
+
+const maxAmount = computed(() => Math.max(...props.items.map(item => item.amountRub), 0))
+
+const getBarHeight = (amount: number) => {
+	if (maxAmount.value <= 0) {
+		return 0
+	}
+
+	return Math.max(4, Math.round((amount / maxAmount.value) * 100))
+}
+
+const shortLabel = (label: string) => label.replace(/\s+\d{4}\s*г\.?$/u, "")
+</script>

--- a/UI/src/components/PortfolioSectorChart.vue
+++ b/UI/src/components/PortfolioSectorChart.vue
@@ -1,0 +1,74 @@
+<template>
+	<div class="space-y-4 rounded-box border border-base-300 bg-base-100 p-4">
+		<div class="flex items-center justify-between gap-3">
+			<h3 class="text-base font-semibold text-base-content">Структура по секторам</h3>
+			<span class="text-xs text-base-content/60">Текущая цена без НКД, RUB</span>
+		</div>
+
+		<div v-if="items.length < 1" class="rounded-box bg-base-200 px-4 py-6 text-sm text-base-content/70">
+			Нет данных по секторам.
+		</div>
+
+		<div v-else class="grid gap-4 md:grid-cols-[12rem_minmax(0,1fr)] md:items-center">
+			<div
+				class="mx-auto h-48 w-48 rounded-full border border-base-300"
+				:style="{ background: chartGradient }"
+			>
+				<div class="mx-auto mt-10 flex h-28 w-28 items-center justify-center rounded-full bg-base-100 text-center text-xs text-base-content/70">
+					<div>
+						<div class="font-semibold text-base-content">{{ formatMoney(totalAmount) }}</div>
+						<div>Всего</div>
+					</div>
+				</div>
+			</div>
+
+			<div class="space-y-2">
+				<div
+					v-for="(item, index) in items"
+					:key="item.sector"
+					class="flex items-start justify-between gap-3 rounded-box bg-base-200 px-3 py-2 text-sm"
+				>
+					<div class="flex min-w-0 items-start gap-2">
+						<span class="mt-1 h-3 w-3 shrink-0 rounded-full" :style="{ backgroundColor: colors[index % colors.length] }"></span>
+						<span class="truncate">{{ SectorsCollation.getLabel(item.sector) }}</span>
+					</div>
+					<div class="shrink-0 text-right">
+						<div class="font-medium text-base-content">{{ formatMoney(item.amountRub) }}</div>
+						<div class="text-xs text-base-content/70">{{ formatPercent(item.sharePct) }}</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script lang="ts" setup>
+import { computed, type PropType } from "vue"
+import SectorsCollation from "@/data/collations/SectorsCollation"
+import type { PortfolioSectorAllocationItem } from "@/data/Interfaces/PortfolioMetrics"
+import { formatMoney, formatPercent } from "@/utils/format"
+
+const colors = ["#2563eb", "#7c3aed", "#ea580c", "#059669", "#dc2626", "#ca8a04", "#0f766e", "#9333ea"]
+
+const props = defineProps({
+	items: {
+		type: Array as PropType<PortfolioSectorAllocationItem[]>,
+		default: () => []
+	}
+})
+
+const totalAmount = computed(() => props.items.reduce((sum, item) => sum + item.amountRub, 0))
+
+const chartGradient = computed(() => {
+	if (props.items.length < 1) {
+		return "conic-gradient(var(--color-base-300) 0deg 360deg)"
+	}
+
+	let currentAngle = 0
+	return `conic-gradient(${props.items.map((item, index) => {
+			const start = currentAngle
+			currentAngle += (item.sharePct / 100) * 360
+			return `${colors[index % colors.length]} ${start}deg ${currentAngle}deg`
+		}).join(", ")})`
+})
+</script>

--- a/UI/src/components/PortfolioStats.vue
+++ b/UI/src/components/PortfolioStats.vue
@@ -1,84 +1,69 @@
 <template>
-	<table class="table table-zebra w-full text-sm">
-		<tbody>
-			<tr>
-				<td class="py-3 pr-4 font-medium">Всего бумаг:</td>
-				<td class="py-3 text-right">{{ totalBonds }}</td>
-			</tr>
-			<tr>
-				<td class="py-3 pr-4 font-medium">Всего купонов:</td>
-				<td class="py-3 text-right">{{ totalCoupons }}</td>
-			</tr>
-			<tr>
-				<td class="py-3 pr-4 font-medium">Профит от купонов:</td>
-				<td class="py-3 text-right">{{ totalProfit }}</td>
-			</tr>
-			<tr>
-				<td class="py-3 pr-4 font-medium">Цена покупки портфеля</td>
-				<td class="py-3 text-right">{{ totalPrice }}</td>
-			</tr>
-		</tbody>
-	</table>
+	<div class="relative flex h-full flex-col gap-4 overflow-auto">
+		<div v-if="loading" class="absolute inset-0 z-10">
+			<loading-overlay />
+		</div>
+
+		<div v-if="!metrics" class="rounded-box border border-base-300 bg-base-100 p-5 text-sm text-base-content/70">
+			Портфель пуст или данные ещё не рассчитаны.
+		</div>
+
+		<template v-else>
+			<div class="rounded-box border border-base-300 bg-base-100 p-4">
+				<table class="table table-zebra w-full text-sm">
+					<tbody>
+						<tr>
+							<td class="py-3 pr-4 font-medium">Всего бумаг:</td>
+							<td class="py-3 text-right">{{ formatInteger(metrics.totals.totalBonds) }}</td>
+						</tr>
+						<tr>
+							<td class="py-3 pr-4 font-medium">Всего купонов:</td>
+							<td class="py-3 text-right">{{ formatInteger(metrics.totals.totalCoupons) }}</td>
+						</tr>
+						<tr>
+							<td class="py-3 pr-4 font-medium">Профит от купонов:</td>
+							<td class="py-3 text-right">{{ formatMoney(metrics.totals.couponProfitRub) }}</td>
+						</tr>
+						<tr>
+							<td class="py-3 pr-4 font-medium">Цена покупки портфеля:</td>
+							<td class="py-3 text-right">{{ formatMoney(metrics.totals.purchaseCostRub) }}</td>
+						</tr>
+						<tr>
+							<td class="py-3 pr-4 font-medium">Профит при погашении:</td>
+							<td class="py-3 text-right">{{ formatMoney(metrics.totals.maturityProfitRub) }}</td>
+						</tr>
+						<tr>
+							<td class="py-3 pr-4 font-medium">Профит при погашении, %:</td>
+							<td class="py-3 text-right">{{ formatPercent(metrics.totals.maturityProfitPct) }}</td>
+						</tr>
+					</tbody>
+				</table>
+
+				<div class="mt-4 grid gap-2 rounded-box bg-base-200 p-3 text-xs text-base-content/70">
+					<div>Данные облигаций: {{ formatDateTime(metrics.actuality.bondsUpdatedAt) }}</div>
+					<div>Курсы ЦБ обновлены: {{ formatDateTime(metrics.actuality.ratesUpdatedAt) }}</div>
+					<div>Дата курсов ЦБ: {{ metrics.actuality.ratesDate }}</div>
+					<div>Портфель рассчитан: {{ formatDateTime(metrics.actuality.generatedAt) }}</div>
+				</div>
+			</div>
+
+			<portfolio-coupon-chart :items="metrics.couponSchedule" />
+			<portfolio-sector-chart :items="metrics.sectorAllocation" />
+		</template>
+	</div>
 </template>
 
-<script lang="tsx">
+<script lang="ts" setup>
 import type { PropType } from "vue"
-import type { CombinedBondsResponse } from "@/data/Interfaces/CombinedBondsResponse"
-import { portfolioStore } from "@/data/portfolioStore"
+import LoadingOverlay from "@/components/UI/LoadingOverlay.vue"
+import type { PortfolioMetricsResponse } from "@/data/Interfaces/PortfolioMetrics"
+import { formatDateTime, formatInteger, formatMoney, formatPercent } from "@/utils/format"
 
-export default {
-	name: "PortfolioStats",
-	methods: { portfolioStore },
-	props: {
-		modelValue: {
-			type: Array as PropType<CombinedBondsResponse[]>,
-			required: true
-		},
-		loading: Boolean
+defineProps({
+	metrics: {
+		type: Object as PropType<PortfolioMetricsResponse | null>,
+		default: null
 	},
-
-	setup(props) {
-		// const totalBonds = ref(0)
-		// const totalCoupons = ref(0)
-		// const totalProfit = ref(0)
-		//
-		// totalBonds.value = props.modelValue.reduce((sum, bond) => sum + bond.qty, 0)
-		// totalCoupons.value = props.modelValue.reduce((sum, bond) => sum + bond.coupons.length, 0)
-		// totalProfit.value = props.modelValue.reduce(
-		// 	(sum, bond) =>
-		// 		sum + bond.coupons.reduce((sum, coupon) => sum + (coupon.isPayed ? coupon.payout : 0), 0),
-		// 	0
-		// )
-		//
-		// return {
-		// 	totalBonds,
-		// 	totalCoupons,
-		// 	totalProfit
-		// }
-	},
-
-	computed: {
-		totalBonds() {
-			return (this.modelValue as CombinedBondsResponse[]).reduce((sum, bond) => sum + bond.qty, 0)
-		},
-		totalPrice() {
-			return Number(
-				(this.modelValue as CombinedBondsResponse[]).reduce(
-					(sum, bond) => sum + ((((bond.price ?? 0) * (bond.nominal ?? 0)) / 100) * bond.qty),
-					0
-				).toFixed(2)
-			)
-		},
-		totalCoupons() {
-			return (this.modelValue as CombinedBondsResponse[]).reduce((sum, bond) => sum + (bond.coupons?.length ?? 0), 0)
-		},
-		totalProfit() {
-			return (this.modelValue as CombinedBondsResponse[]).reduce(
-				(sum, bond) =>
-					sum + (bond.coupons?.reduce((couponSum, coupon) => couponSum + (coupon.payout ?? 0), 0) ?? 0),
-				0
-			)
-		}
-	}
-}
+	loading: Boolean
+})
 </script>

--- a/UI/src/components/PortfolioStats.vue
+++ b/UI/src/components/PortfolioStats.vue
@@ -29,12 +29,12 @@
 							<td class="py-3 text-right">{{ formatMoney(metrics.totals.purchaseCostRub) }}</td>
 						</tr>
 						<tr>
-							<td class="py-3 pr-4 font-medium">Профит при погашении:</td>
-							<td class="py-3 text-right">{{ formatMoney(metrics.totals.maturityProfitRub) }}</td>
+							<td class="py-3 pr-4 font-medium">Сумма при погашении:</td>
+							<td class="py-3 text-right">{{ formatMoney(metrics.totals.maturityValueRub) }}</td>
 						</tr>
 						<tr>
-							<td class="py-3 pr-4 font-medium">Профит при погашении, %:</td>
-							<td class="py-3 text-right">{{ formatPercent(metrics.totals.maturityProfitPct) }}</td>
+							<td class="py-3 pr-4 font-medium">Сумма при погашении, % к покупке:</td>
+							<td class="py-3 text-right">{{ formatPercent(metrics.totals.maturityValuePct) }}</td>
 						</tr>
 					</tbody>
 				</table>

--- a/UI/src/data/BondsRepository.ts
+++ b/UI/src/data/BondsRepository.ts
@@ -2,6 +2,7 @@ import { httpClient } from '@/plugins/axios'
 import type { CombinedBondsResponse } from '@/data/Interfaces/CombinedBondsResponse'
 import type { CombinedCoupon } from "@/data/Interfaces/CombinedCoupon"
 import type { BondsDataStatus } from "@/data/Interfaces/BondsDataStatus"
+import type { PortfolioMetricsResponse, PortfolioPositionInput } from "@/data/Interfaces/PortfolioMetrics"
 
 export default class BondsRepository {
   $http = httpClient
@@ -21,5 +22,9 @@ export default class BondsRepository {
 
   async coupons(id: string): Promise<CombinedCoupon[]> {
     return this.$http.get(`${this.getEndpoint()}/coupons`, { params: { id } }).then((res) => res.data  as CombinedCoupon[])
+  }
+
+  async portfolioMetrics(positions: PortfolioPositionInput[]): Promise<PortfolioMetricsResponse> {
+    return this.$http.post(`${this.getEndpoint()}/portfolioMetrics`, { positions }).then((res) => res.data as PortfolioMetricsResponse)
   }
 }

--- a/UI/src/data/Interfaces/PortfolioMetrics.ts
+++ b/UI/src/data/Interfaces/PortfolioMetrics.ts
@@ -1,0 +1,40 @@
+export interface PortfolioPositionInput {
+	uid: string
+	qty: number
+}
+
+export interface PortfolioTotals {
+	totalBonds: number
+	totalCoupons: number
+	purchaseCostRub: number
+	couponProfitRub: number
+	maturityProfitRub: number
+	maturityProfitPct: number
+}
+
+export interface PortfolioCouponScheduleItem {
+	month: string
+	label: string
+	amountRub: number
+}
+
+export interface PortfolioSectorAllocationItem {
+	sector: string
+	amountRub: number
+	sharePct: number
+}
+
+export interface PortfolioActuality {
+	bondsUpdatedAt?: string
+	ratesUpdatedAt: string
+	ratesDate: string
+	generatedAt: string
+}
+
+export interface PortfolioMetricsResponse {
+	baseCurrency: "RUB"
+	totals: PortfolioTotals
+	couponSchedule: PortfolioCouponScheduleItem[]
+	sectorAllocation: PortfolioSectorAllocationItem[]
+	actuality: PortfolioActuality
+}

--- a/UI/src/data/Interfaces/PortfolioMetrics.ts
+++ b/UI/src/data/Interfaces/PortfolioMetrics.ts
@@ -8,8 +8,8 @@ export interface PortfolioTotals {
 	totalCoupons: number
 	purchaseCostRub: number
 	couponProfitRub: number
-	maturityProfitRub: number
-	maturityProfitPct: number
+	maturityValueRub: number
+	maturityValuePct: number
 }
 
 export interface PortfolioCouponScheduleItem {

--- a/UI/src/utils/format.ts
+++ b/UI/src/utils/format.ts
@@ -1,0 +1,40 @@
+const integerFormatter = new Intl.NumberFormat("ru-RU", {
+	maximumFractionDigits: 0,
+})
+
+const moneyFormatter = new Intl.NumberFormat("ru-RU", {
+	minimumFractionDigits: 2,
+	maximumFractionDigits: 2,
+})
+
+export function formatInteger(value?: number | null) {
+	if (value === undefined || value === null || Number.isNaN(value)) {
+		return "—"
+	}
+
+	return integerFormatter.format(value)
+}
+
+export function formatMoney(value?: number | null, currency = "RUB") {
+	if (value === undefined || value === null || Number.isNaN(value)) {
+		return "—"
+	}
+
+	return `${moneyFormatter.format(value)} ${currency}`
+}
+
+export function formatPercent(value?: number | null) {
+	if (value === undefined || value === null || Number.isNaN(value)) {
+		return "—"
+	}
+
+	return `${moneyFormatter.format(value)}%`
+}
+
+export function formatDateTime(value?: string) {
+	if (!value) {
+		return "—"
+	}
+
+	return new Date(value).toLocaleString("ru-RU")
+}

--- a/UI/src/utils/metrika.ts
+++ b/UI/src/utils/metrika.ts
@@ -1,8 +1,8 @@
 export default function addMetrika(metrikaId: string) {
   window.ym =
     window.ym ||
-    function () {
-      ;(window.ym!.a = window.ym!.a || []).push(arguments)
+    function (...args: unknown[]) {
+      ;(window.ym!.a = window.ym!.a || []).push(args)
     }
   window.ym.l = Date.now()
 
@@ -16,45 +16,9 @@ export default function addMetrika(metrikaId: string) {
   noscript.innerHTML = `<div><img src="https://mc.yandex.ru/watch/${metrikaId}" style="position:absolute; left:-9999px;" alt="" /></div>`
   document.body.appendChild(noscript)
 
-  // initMetrika(metrikaId)
-  //
-  // // -- init script
-  // const script2 = document.createElement('script');
-  // script2.type = 'text/javascript';
-  // script2.innerHTML = `
-  //     ym(${metrikaId}, "init", {
-  //     clickmap:true,
-  //     trackLinks:true,
-  //     accurateTrackBounce:true
-  //   });
-  // `;
-  // document.body.appendChild(script2);
-  // // -- end of init script
-  //
-  // // check if ym is defined in window and then run init script
-  // if (typeof window.ym !== 'undefined') {
-    window.ym?.(metrikaId, 'init', {
-      clickmap:true,
-      trackLinks:true,
-      accurateTrackBounce:true
-    });
-  // }else{
-  //   // if not defined, wait for 100ms and try again
-  //   setTimeout(addMetrika, 100);
-  // }
-}
-
-function initMetrika(metrikaId: string) {
-  // check if ym is defined in window and then run init script
-  if (typeof window.ym !== 'undefined') {
-    window.ym(metrikaId, 'init', {
-      clickmap: true,
-      trackLinks: true,
-      accurateTrackBounce: true
-    })
-  } else {
-    // if not defined, wait for 100ms and try again
-    setTimeout(initMetrika, 100)
-    console.log('waiting')
-  }
+  window.ym?.(metrikaId, 'init', {
+    clickmap: true,
+    trackLinks: true,
+    accurateTrackBounce: true
+  })
 }

--- a/UI/src/utils/portfolio.test.ts
+++ b/UI/src/utils/portfolio.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { formatDateTime, formatInteger, formatMoney, formatPercent } from "./format"
+
+describe("portfolio formatters", () => {
+	test("formats integer values without fraction digits", () => {
+		expect(formatInteger(1234)).toBe("1 234")
+	})
+
+	test("formats money values with two fraction digits and currency", () => {
+		expect(formatMoney(1234.5)).toBe("1 234,50 RUB")
+	})
+
+	test("formats percent values with two fraction digits", () => {
+		expect(formatPercent(12.345)).toBe("12,35%")
+	})
+
+	test("formats date time using ru locale", () => {
+		expect(formatDateTime("2026-04-20T05:00:00.000Z")).toContain("20.04.2026")
+	})
+})

--- a/UI/src/views/PortfolioView.vue
+++ b/UI/src/views/PortfolioView.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="grid grid-cols-1 gap-5 xl:grid-cols-[minmax(0,2fr)_minmax(20rem,1fr)]">
+	<div class="grid grid-cols-1 gap-5 xl:grid-cols-[minmax(0,2fr)_minmax(24rem,1fr)] 2xl:grid-cols-[minmax(0,2fr)_minmax(28rem,1fr)]">
 		<!-- table -->
 
 		<div
@@ -16,8 +16,8 @@
 		<div
 			class="card card-border min-w-0 h-[calc(100vh-var(--header-height)-1px)] bg-base-100"
 		>
-			<div class="card-body h-full">
-				<portfolio-stats v-model="portfolioBonds" :loading="isFetching" />
+			<div class="card-body h-full overflow-hidden">
+				<portfolio-stats :metrics="portfolioMetrics" :loading="isFetching" />
 			</div>
 		</div>
 	</div>
@@ -25,37 +25,48 @@
 
 <script lang="ts">
 import { portfolioStore } from "@/data/portfolioStore"
-import { onMounted, ref, computed } from "vue"
+import { ref, computed, watch } from "vue"
 import BondsRepository from "@/data/BondsRepository"
+import type { PortfolioMetricsResponse, PortfolioPositionInput } from "@/data/Interfaces/PortfolioMetrics"
 
 export default {
 	name: "PortfolioView",
 	setup() {
-		const isFetching = ref(true)
+		const isFetching = ref(false)
 		const store = portfolioStore()
 		const portfolioBonds = computed(() => store.values)
+		const portfolioPositions = computed<PortfolioPositionInput[]>(() =>
+			store.values.map((bond) => ({ uid: bond.uid, qty: bond.qty }))
+		)
+		const portfolioMetrics = ref<PortfolioMetricsResponse | null>(null)
 		const bondsRepository = new BondsRepository()
 
-		onMounted(async () => {
-			const bonds = store.values
-			if (bonds.length === 0) {
+		const fetchPortfolioMetrics = async (positions: PortfolioPositionInput[]) => {
+			if (positions.length < 1) {
+				portfolioMetrics.value = null
 				isFetching.value = false
 				return
 			}
+
+			isFetching.value = true
 			try {
-				const results = await Promise.all(
-					bonds.map((bond) => bondsRepository.coupons(bond.figi))
-				)
-				results.forEach((coupons, i) => {
-					store.setBondCoupons(bonds[i].uid, coupons)
-				})
+				portfolioMetrics.value = await bondsRepository.portfolioMetrics(positions)
 			} finally {
 				isFetching.value = false
 			}
-		})
+		}
+
+		watch(
+			portfolioPositions,
+			(positions) => {
+				void fetchPortfolioMetrics(positions)
+			},
+			{ deep: true, immediate: true }
+		)
 
 		return {
 			portfolioBonds,
+			portfolioMetrics,
 			isFetching
 		}
 	}

--- a/UI/tsconfig.app.json
+++ b/UI/tsconfig.app.json
@@ -7,6 +7,7 @@
   ],
   "exclude": [
     "src/**/__tests__/*",
+    "src/**/*.test.ts",
     "src/external",
     "src/external/**/*"
   ],

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "start": "bun ./node_modules/.bin/moleculer-runner --config dist/moleculer.config.js dist/src/services/{**,**/**,**/**/**}/*.service.js",
     "cli": "moleculer connect NATS",
     "ci": "bun test --watch",
-    "test": "bun test src/common/api/createInvestApi.test.ts && bun test src/common/buildBondsData.test.ts && bun test src/common/fetchGate.test.ts && bun test src/common/getCurrencyRates.test.ts && bun test src/common/getMoexData.test.ts && bun test src/common/getOrBuildBondsData.test.ts && bun test src/common/investApiFacade.test.ts && bun test src/common/utils/sleep.test.ts && bun test src/services/bonds.service.test.ts && bun test src/services/scheduler.service.test.ts",
+    "test": "bun test src/common/api/createInvestApi.test.ts && bun test src/common/buildBondsData.test.ts && bun test src/common/fetchGate.test.ts && bun test src/common/getCurrencyRates.test.ts && bun test src/common/getMoexData.test.ts && bun test src/common/getOrBuildBondsData.test.ts && bun test src/common/getPortfolioMetrics.test.ts && bun test src/common/investApiFacade.test.ts && bun test src/common/utils/sleep.test.ts && bun test src/services/bonds.service.test.ts && bun test src/services/scheduler.service.test.ts",
     "coverage": "bun test --coverage",
     "lint": "eslint --ext .js,.ts src scripts moleculer.config.ts",
     "typeorm": "bun run scripts/typeorm-run.ts",

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "start": "bun ./node_modules/.bin/moleculer-runner --config dist/moleculer.config.js dist/src/services/{**,**/**,**/**/**}/*.service.js",
     "cli": "moleculer connect NATS",
     "ci": "bun test --watch",
-    "test": "bun test src/common/api/createInvestApi.test.ts && bun test src/common/buildBondsData.test.ts && bun test src/common/fetchGate.test.ts && bun test src/common/getMoexData.test.ts && bun test src/common/getOrBuildBondsData.test.ts && bun test src/common/investApiFacade.test.ts && bun test src/common/utils/sleep.test.ts && bun test src/services/bonds.service.test.ts",
+    "test": "bun test src/common/api/createInvestApi.test.ts && bun test src/common/buildBondsData.test.ts && bun test src/common/fetchGate.test.ts && bun test src/common/getCurrencyRates.test.ts && bun test src/common/getMoexData.test.ts && bun test src/common/getOrBuildBondsData.test.ts && bun test src/common/investApiFacade.test.ts && bun test src/common/utils/sleep.test.ts && bun test src/services/bonds.service.test.ts && bun test src/services/scheduler.service.test.ts",
     "coverage": "bun test --coverage",
     "lint": "eslint --ext .js,.ts src scripts moleculer.config.ts",
     "typeorm": "bun run scripts/typeorm-run.ts",

--- a/server/src/common/buildBondsData.ts
+++ b/server/src/common/buildBondsData.ts
@@ -1,27 +1,15 @@
 import moment from "moment/moment"
-import { createCache } from "./cache"
 import { getMoexData } from "./getMoexData"
 import { mapWithConcurrency } from "./getMoexData"
+import { getCouponSummary } from "./getCouponSummary"
 import { CombinedBondsResponse } from "./interfaces/CombinedBondsResponse"
-import { listBonds, getLastPrices, getBondCoupons } from "./investApiFacade"
+import { listBonds, getLastPrices } from "./investApiFacade"
 import { isMoneyLike, toNumber } from "./utils/money"
 import { roundTo } from "./utils/round"
-import { sleep } from "./utils/sleep"
 
 const COUPON_FALLBACK_CONCURRENCY = 1
-const COUPON_FALLBACK_DELAY_MS = 400
-const COUPON_FALLBACK_MAX_RETRIES = 4
-const COUPON_FALLBACK_CACHE_TTL_SECONDS = 60 * 60 * 24
-
-interface CachedCouponSummary {
-	coupons: { couponDate?: string | Date, payout?: number, couponNumber?: number }[]
-	annualCouponSum?: number
-	leftToPay?: number
-	leftCouponCount: number
-}
 
 export async function buildBondsData(): Promise<CombinedBondsResponse[]> {
-  const couponCache = createCache({ ttl: COUPON_FALLBACK_CACHE_TTL_SECONDS })
   const bonds = await listBonds()
 
   const instrumentIDs: string[] = bonds.map(instrument => instrument.uid)
@@ -75,7 +63,7 @@ export async function buildBondsData(): Promise<CombinedBondsResponse[]> {
 
   await mapWithConcurrency(bondsMissingMoexData, COUPON_FALLBACK_CONCURRENCY, async instrument => {
     try {
-      const couponSummary = await getCouponSummary(String(instrument.figi), Boolean(instrument.floatingCouponFlag), couponCache, now)
+      const couponSummary = await getCouponSummary(String(instrument.figi), Boolean(instrument.floatingCouponFlag), now)
       if (!couponSummary) {
         return
       }
@@ -103,90 +91,4 @@ export async function buildBondsData(): Promise<CombinedBondsResponse[]> {
   })
 
   return response
-}
-
-async function getCouponSummary(figi: string, isFloatingCoupon: boolean, couponCache, now: moment.Moment): Promise<CachedCouponSummary | undefined> {
-	const cacheKey = `bondCoupons.${figi}`
-	const cachedSummary = await couponCache.get(cacheKey) as CachedCouponSummary | undefined
-	if (cachedSummary) {
-		return cachedSummary
-	}
-
-	const coupons = await getBondCouponsWithRetry(figi)
-	const futureCoupons = coupons
-		.filter(coupon => moment(coupon.couponDate).isAfter(now))
-		.sort((a, b) => moment(a.couponDate).valueOf() - moment(b.couponDate).valueOf())
-
-	if (futureCoupons.length < 1) {
-		return undefined
-	}
-
-	const lastKnownPayout = findLastKnownPayout(coupons)
-	const normalizedCoupons = futureCoupons.map(coupon => ({
-		couponDate: coupon.couponDate,
-		couponNumber: coupon.couponNumber,
-		payout: getCouponPayout(coupon, isFloatingCoupon, lastKnownPayout),
-	}))
-	const oneYearLater = now.clone().add(1, "year")
-	const annualCouponSum = roundTo(normalizedCoupons.reduce((sum, coupon) =>
-		moment(coupon.couponDate).isSameOrBefore(oneYearLater)
-			? sum + (coupon.payout ?? 0)
-			: sum
-	, 0))
-	const leftToPay = roundTo(normalizedCoupons.reduce((sum, coupon) => sum + (coupon.payout ?? 0), 0))
-	const couponSummary: CachedCouponSummary = {
-		coupons: normalizedCoupons,
-		annualCouponSum,
-		leftToPay,
-		leftCouponCount: normalizedCoupons.length,
-	}
-
-	await couponCache.set(cacheKey, couponSummary)
-	return couponSummary
-}
-
-async function getBondCouponsWithRetry(figi: string) {
-	let lastError: unknown
-
-	for (let attempt = 1; attempt <= COUPON_FALLBACK_MAX_RETRIES; attempt++) {
-		try {
-			if (attempt > 1) {
-				await sleep(COUPON_FALLBACK_DELAY_MS * attempt)
-			}
-			const coupons = await getBondCoupons(figi)
-			await sleep(COUPON_FALLBACK_DELAY_MS)
-			return coupons
-		} catch (error) {
-			lastError = error
-			if (!String(error?.message ?? error).includes("RESOURCE_EXHAUSTED") || attempt === COUPON_FALLBACK_MAX_RETRIES) {
-				throw error
-			}
-		}
-	}
-
-	throw lastError
-}
-
-function findLastKnownPayout(coupons: { payOneBond?: { units: number, nano: number } }[]) {
-	for (const coupon of coupons) {
-		const payout = roundTo(toNumber(coupon.payOneBond))
-		if (payout !== undefined && payout > 0) {
-			return payout
-		}
-	}
-
-	return undefined
-}
-
-function getCouponPayout(
-	coupon: { payOneBond?: { units: number, nano: number } },
-	isFloatingCoupon: boolean,
-	lastKnownPayout?: number,
-) {
-	const payout = roundTo(toNumber(coupon.payOneBond))
-	if (payout !== undefined && payout > 0) {
-		return payout
-	}
-
-	return isFloatingCoupon ? lastKnownPayout : payout
 }

--- a/server/src/common/getCouponSummary.ts
+++ b/server/src/common/getCouponSummary.ts
@@ -1,0 +1,110 @@
+import moment from "moment/moment"
+import { createCache } from "./cache"
+import { CombinedCoupon } from "./interfaces/CombinedCoupon"
+import { getBondCoupons } from "./investApiFacade"
+import { toNumber } from "./utils/money"
+import { roundTo } from "./utils/round"
+import { sleep } from "./utils/sleep"
+
+const COUPON_FALLBACK_DELAY_MS = 400
+const COUPON_FALLBACK_MAX_RETRIES = 4
+const COUPON_FALLBACK_CACHE_TTL_SECONDS = 60 * 60 * 24
+
+export interface CouponSummary {
+	coupons: CombinedCoupon[]
+	annualCouponSum?: number
+	leftToPay?: number
+	leftCouponCount: number
+}
+
+const couponCache = createCache({ ttl: COUPON_FALLBACK_CACHE_TTL_SECONDS })
+
+export async function getCouponSummary(
+	figi: string,
+	isFloatingCoupon: boolean,
+	now = moment(),
+): Promise<CouponSummary | undefined> {
+	const cacheKey = `bondCoupons.${figi}`
+	const cachedSummary = await couponCache.get(cacheKey) as CouponSummary | undefined
+	if (cachedSummary) {
+		return cachedSummary
+	}
+
+	const coupons = await getBondCouponsWithRetry(figi)
+	const futureCoupons = coupons
+		.filter(coupon => moment(coupon.couponDate).isAfter(now))
+		.sort((a, b) => moment(a.couponDate).valueOf() - moment(b.couponDate).valueOf())
+
+	if (futureCoupons.length < 1) {
+		return undefined
+	}
+
+	const lastKnownPayout = findLastKnownPayout(coupons)
+	const normalizedCoupons = futureCoupons.map(coupon => ({
+		couponDate: coupon.couponDate,
+		couponNumber: coupon.couponNumber,
+		payout: getCouponPayout(coupon, isFloatingCoupon, lastKnownPayout),
+	}))
+	const oneYearLater = now.clone().add(1, "year")
+	const annualCouponSum = roundTo(normalizedCoupons.reduce((sum, coupon) =>
+		moment(coupon.couponDate).isSameOrBefore(oneYearLater)
+			? sum + (coupon.payout ?? 0)
+			: sum
+	, 0))
+	const leftToPay = roundTo(normalizedCoupons.reduce((sum, coupon) => sum + (coupon.payout ?? 0), 0))
+	const couponSummary: CouponSummary = {
+		coupons: normalizedCoupons,
+		annualCouponSum,
+		leftToPay,
+		leftCouponCount: normalizedCoupons.length,
+	}
+
+	await couponCache.set(cacheKey, couponSummary)
+	return couponSummary
+}
+
+async function getBondCouponsWithRetry(figi: string) {
+	let lastError: unknown
+
+	for (let attempt = 1; attempt <= COUPON_FALLBACK_MAX_RETRIES; attempt++) {
+		try {
+			if (attempt > 1) {
+				await sleep(COUPON_FALLBACK_DELAY_MS * attempt)
+			}
+			const coupons = await getBondCoupons(figi)
+			await sleep(COUPON_FALLBACK_DELAY_MS)
+			return coupons
+		} catch (error) {
+			lastError = error
+			if (!String(error?.message ?? error).includes("RESOURCE_EXHAUSTED") || attempt === COUPON_FALLBACK_MAX_RETRIES) {
+				throw error
+			}
+		}
+	}
+
+	throw lastError
+}
+
+function findLastKnownPayout(coupons: { payOneBond?: { units: number, nano: number } }[]) {
+	for (const coupon of coupons) {
+		const payout = roundTo(toNumber(coupon.payOneBond))
+		if (payout !== undefined && payout > 0) {
+			return payout
+		}
+	}
+
+	return undefined
+}
+
+function getCouponPayout(
+	coupon: { payOneBond?: { units: number, nano: number } },
+	isFloatingCoupon: boolean,
+	lastKnownPayout?: number,
+) {
+	const payout = roundTo(toNumber(coupon.payOneBond))
+	if (payout !== undefined && payout > 0) {
+		return payout
+	}
+
+	return isFloatingCoupon ? lastKnownPayout : payout
+}

--- a/server/src/common/getCurrencyRates.test.ts
+++ b/server/src/common/getCurrencyRates.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test"
+
+const axiosGetMock = mock(async () => ({ data: "" }))
+let cacheStore = new Map<string, unknown>()
+
+mock.module("axios", () => ({
+	default: {
+		get: axiosGetMock,
+	},
+}))
+
+mock.module("file-system-cache", () => ({
+	default: () => ({
+		get: async (key: string) => cacheStore.get(key),
+		set: async (key: string, value: unknown) => {
+			cacheStore.set(key, value)
+		},
+	}),
+}))
+
+const { convertToRub, getCurrencyRate, parseCurrencyRatesXml, refreshCurrencyRates } = await import("./getCurrencyRates")
+
+describe("getCurrencyRates", () => {
+	beforeEach(() => {
+		axiosGetMock.mockReset()
+		cacheStore = new Map<string, unknown>()
+	})
+
+	test("parses CBR XML and normalizes rates to one currency unit", () => {
+		const snapshot = parseCurrencyRatesXml(`
+			<ValCurs Date="20.04.2026" name="Foreign Currency Market">
+				<Valute ID="R01235">
+					<CharCode>USD</CharCode>
+					<Nominal>1</Nominal>
+					<Value>82,5500</Value>
+				</Valute>
+				<Valute ID="R01820">
+					<CharCode>JPY</CharCode>
+					<Nominal>100</Nominal>
+					<Value>55,1234</Value>
+				</Valute>
+			</ValCurs>
+		`, new Date("2026-04-20T04:00:00.000Z"))
+
+		expect(snapshot.rateDate).toBe("20.04.2026")
+		expect(snapshot.rates.USD.rate).toBe(82.55)
+		expect(snapshot.rates.JPY.rate).toBe(0.551234)
+	})
+
+	test("returns cached snapshot when refresh fails", async () => {
+		cacheStore.set("currencyRates", {
+			baseCurrency: "RUB",
+			rateDate: "19.04.2026",
+			updatedAt: "2026-04-19T04:00:00.000Z",
+			rates: {
+				USD: { charCode: "USD", nominal: 1, value: 80, rate: 80 },
+			},
+		})
+		axiosGetMock.mockRejectedValueOnce(new Error("boom"))
+
+		const snapshot = await refreshCurrencyRates()
+
+		expect(snapshot.rateDate).toBe("19.04.2026")
+		expect(snapshot.rates.USD.rate).toBe(80)
+	})
+
+	test("refreshes and stores new snapshot when request succeeds", async () => {
+		axiosGetMock.mockResolvedValueOnce({
+			data: `
+				<ValCurs Date="20.04.2026">
+					<Valute ID="R01235">
+						<CharCode>USD</CharCode>
+						<Nominal>1</Nominal>
+						<Value>81,5000</Value>
+					</Valute>
+				</ValCurs>
+			`,
+		})
+
+		const snapshot = await refreshCurrencyRates(new Date("2026-04-20T05:00:00.000Z"))
+
+		expect(axiosGetMock).toHaveBeenCalledTimes(1)
+		expect(snapshot.rates.USD.rate).toBe(81.5)
+		expect(getCurrencyRate(snapshot, "RUB")).toBe(1)
+		expect(convertToRub(10, "USD", snapshot)).toBe(815)
+	})
+})

--- a/server/src/common/getCurrencyRates.ts
+++ b/server/src/common/getCurrencyRates.ts
@@ -1,0 +1,144 @@
+import axios from "axios"
+import { createCache } from "./cache"
+import { roundTo } from "./utils/round"
+
+const cache = createCache()
+const CBR_DAILY_URL = "https://www.cbr.ru/scripts/XML_daily.asp"
+const CACHE_KEY = "currencyRates"
+
+export interface CurrencyRateEntry {
+	charCode: string
+	nominal: number
+	value: number
+	rate: number
+}
+
+export interface CurrencyRatesSnapshot {
+	baseCurrency: "RUB"
+	rateDate: string
+	updatedAt: string
+	rates: Record<string, CurrencyRateEntry>
+}
+
+export async function getCachedCurrencyRates() {
+	const cached = await cache.get(CACHE_KEY)
+	return isCurrencyRatesSnapshot(cached) ? cached : null
+}
+
+export async function getOrRefreshCurrencyRates() {
+	const cached = await getCachedCurrencyRates()
+	if (cached) {
+		return cached
+	}
+
+	return refreshCurrencyRates()
+}
+
+export async function refreshCurrencyRates(now = new Date()) {
+	const cached = await getCachedCurrencyRates()
+
+	try {
+		const response = await axios.get(CBR_DAILY_URL, {
+			headers: { Accept: "application/xml,text/xml;q=0.9,*/*;q=0.8" },
+			responseType: "text",
+			timeout: 20_000,
+		})
+		const snapshot = parseCurrencyRatesXml(String(response.data), now)
+		await cache.set(CACHE_KEY, snapshot)
+		return snapshot
+	} catch (error) {
+		if (cached) {
+			console.error("[currencyRates] Failed to refresh rates, using cached snapshot:", error?.message ?? error)
+			return cached
+		}
+
+		throw error
+	}
+}
+
+export function getCurrencyRate(snapshot: CurrencyRatesSnapshot, currency: string | undefined) {
+	if (!currency) {
+		return undefined
+	}
+
+	const normalized = currency.toUpperCase()
+	if (normalized === "RUB" || normalized === "RUR") {
+		return 1
+	}
+
+	return snapshot.rates[normalized]?.rate
+}
+
+export function convertToRub(amount: number | undefined, currency: string | undefined, snapshot: CurrencyRatesSnapshot) {
+	if (amount === undefined) {
+		return undefined
+	}
+
+	const rate = getCurrencyRate(snapshot, currency)
+	if (rate === undefined) {
+		throw new Error(`Missing CBR rate for ${currency}`)
+	}
+
+	return roundTo(amount * rate)
+}
+
+export function parseCurrencyRatesXml(xml: string, now = new Date()): CurrencyRatesSnapshot {
+	const dateMatch = xml.match(/<ValCurs[^>]*Date="([^"]+)"/i)
+	if (!dateMatch) {
+		throw new Error("Failed to parse CBR rates date")
+	}
+
+	const rates: Record<string, CurrencyRateEntry> = {}
+	const valuteMatches = xml.match(/<Valute[\s\S]*?<\/Valute>/gi) ?? []
+	for (const valuteXml of valuteMatches) {
+		const charCode = readXmlTag(valuteXml, "CharCode")?.toUpperCase()
+		const nominal = parseXmlNumber(readXmlTag(valuteXml, "Nominal"))
+		const value = parseXmlNumber(readXmlTag(valuteXml, "Value"))
+
+		if (!charCode || nominal === undefined || value === undefined || nominal <= 0) {
+			continue
+		}
+
+		const rate = roundTo(value / nominal, 6)
+		if (rate === undefined) {
+			continue
+		}
+
+		rates[charCode] = {
+			charCode,
+			nominal,
+			value,
+			rate,
+		}
+	}
+
+	return {
+		baseCurrency: "RUB",
+		rateDate: dateMatch[1],
+		updatedAt: now.toISOString(),
+		rates,
+	}
+}
+
+function parseXmlNumber(value: string | undefined) {
+	if (!value) {
+		return undefined
+	}
+
+	const normalized = Number(value.replace(/\s+/g, "").replace(",", "."))
+	return Number.isFinite(normalized) ? normalized : undefined
+}
+
+function readXmlTag(xml: string, tag: string) {
+	const match = xml.match(new RegExp(`<${tag}>([\\s\\S]*?)<\\/${tag}>`, "i"))
+	return match?.[1]?.trim()
+}
+
+function isCurrencyRatesSnapshot(value: unknown): value is CurrencyRatesSnapshot {
+	return typeof value === "object"
+		&& value !== null
+		&& "baseCurrency" in value
+		&& "rateDate" in value
+		&& "updatedAt" in value
+		&& "rates" in value
+}

--- a/server/src/common/getPortfolioMetrics.test.ts
+++ b/server/src/common/getPortfolioMetrics.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, mock, test } from "bun:test"
+import moment from "moment"
+
+const getCouponSummaryMock = mock(async () => undefined)
+
+mock.module("./getCouponSummary", () => ({
+	getCouponSummary: getCouponSummaryMock,
+}))
+
+const { getPortfolioMetrics } = await import("./getPortfolioMetrics")
+
+describe("getPortfolioMetrics", () => {
+	test("calculates totals, coupon schedule and sector allocation in rubles", async () => {
+		const result = await getPortfolioMetrics(
+			[
+				{ uid: "bond-rub", qty: 2 },
+				{ uid: "bond-usd", qty: 1 },
+			],
+			[
+				{
+					uid: "bond-rub",
+					figi: "figi-rub",
+					currency: "rub",
+					sector: "energy",
+					nominal: 1000,
+					price: 90,
+					aciValue: 10,
+					leftToPay: 60,
+					leftCouponCount: 3,
+					coupons: [
+						{ couponDate: "2026-05-15T00:00:00.000Z", payout: 20 },
+						{ couponDate: "2026-06-15T00:00:00.000Z", payout: 20 },
+						{ couponDate: "2027-05-15T00:00:00.000Z", payout: 20 },
+					],
+				} as any,
+				{
+					uid: "bond-usd",
+					figi: "figi-usd",
+					currency: "usd",
+					sector: "it",
+					nominal: 100,
+					price: 95,
+					aciValue: 5,
+					leftToPay: 15,
+					leftCouponCount: 2,
+					coupons: [
+						{ couponDate: "2026-05-20T00:00:00.000Z", payout: 10 },
+						{ couponDate: "2026-11-20T00:00:00.000Z", payout: 5 },
+					],
+				} as any,
+			],
+			{
+				baseCurrency: "RUB",
+				rateDate: "20.04.2026",
+				updatedAt: "2026-04-20T04:00:00.000Z",
+				rates: {
+					USD: { charCode: "USD", nominal: 1, value: 80, rate: 80 },
+				},
+			},
+			{
+				isBuilding: false,
+				hasCachedData: true,
+				lastBuildCompletedAt: "2026-04-20T03:00:00.000Z",
+			},
+			moment("2026-04-20T00:00:00.000Z"),
+		)
+
+		expect(result.totals).toEqual({
+			totalBonds: 3,
+			totalCoupons: 8,
+			purchaseCostRub: 9820,
+			couponProfitRub: 1320,
+			maturityProfitRub: 1500,
+			maturityProfitPct: 15.27,
+		})
+		expect(result.couponSchedule[0]).toEqual({ month: "2026-04", label: "апр. 2026 г.", amountRub: 0 })
+		expect(result.couponSchedule[1]).toEqual({ month: "2026-05", label: "май 2026 г.", amountRub: 840 })
+		expect(result.couponSchedule[2]).toEqual({ month: "2026-06", label: "июнь 2026 г.", amountRub: 40 })
+		expect(result.couponSchedule[7]).toEqual({ month: "2026-11", label: "нояб. 2026 г.", amountRub: 400 })
+		expect(result.sectorAllocation).toEqual([
+			{ sector: "it", amountRub: 7600, sharePct: 80.85 },
+			{ sector: "energy", amountRub: 1800, sharePct: 19.15 },
+		])
+		expect(result.actuality).toEqual({
+			bondsUpdatedAt: "2026-04-20T03:00:00.000Z",
+			ratesUpdatedAt: "2026-04-20T04:00:00.000Z",
+			ratesDate: "20.04.2026",
+			generatedAt: "2026-04-20T00:00:00.000Z",
+		})
+	})
+
+	test("falls back to coupon summary lookup when cached bond data is incomplete", async () => {
+		getCouponSummaryMock.mockResolvedValueOnce({
+			leftToPay: 30,
+			leftCouponCount: 2,
+			coupons: [{ couponDate: "2026-05-01T00:00:00.000Z", payout: 15 }],
+		})
+
+		const result = await getPortfolioMetrics(
+			[{ uid: "bond-1", qty: 1 }],
+			[{ uid: "bond-1", figi: "figi-1", currency: "rub", sector: "other", nominal: 1000, price: 100, aciValue: 0 } as any],
+			{ baseCurrency: "RUB", rateDate: "20.04.2026", updatedAt: "2026-04-20T04:00:00.000Z", rates: {} },
+			{ isBuilding: false, hasCachedData: true },
+			moment("2026-04-20T00:00:00.000Z"),
+		)
+
+		expect(getCouponSummaryMock).toHaveBeenCalledWith("figi-1", false, expect.anything())
+		expect(result.totals.totalCoupons).toBe(2)
+		expect(result.totals.couponProfitRub).toBe(30)
+	})
+})

--- a/server/src/common/getPortfolioMetrics.test.ts
+++ b/server/src/common/getPortfolioMetrics.test.ts
@@ -70,8 +70,8 @@ describe("getPortfolioMetrics", () => {
 			totalCoupons: 8,
 			purchaseCostRub: 9820,
 			couponProfitRub: 1320,
-			maturityProfitRub: 1500,
-			maturityProfitPct: 15.27,
+			maturityValueRub: 11320,
+			maturityValuePct: 115.27,
 		})
 		expect(result.couponSchedule[0]).toEqual({ month: "2026-04", label: "апр. 2026 г.", amountRub: 0 })
 		expect(result.couponSchedule[1]).toEqual({ month: "2026-05", label: "май 2026 г.", amountRub: 840 })

--- a/server/src/common/getPortfolioMetrics.ts
+++ b/server/src/common/getPortfolioMetrics.ts
@@ -25,7 +25,7 @@ export async function getPortfolioMetrics(
 	let totalCoupons = 0
 	let purchaseCostRub = 0
 	let couponProfitRub = 0
-	let maturityProfitRub = 0
+	let maturityValueRub = 0
 
 	for (const position of positions) {
 		const qty = Math.max(0, Math.trunc(position.qty))
@@ -45,14 +45,14 @@ export async function getPortfolioMetrics(
 		const cleanPrice = nominal > 0 && bond.price !== undefined ? (nominal * bond.price) / 100 : 0
 		const purchaseCostLocal = (cleanPrice + aciValue) * qty
 		const couponProfitLocal = (couponSummary?.leftToPay ?? 0) * qty
-		const maturityProfitLocal = (nominal + (couponSummary?.leftToPay ?? 0) - cleanPrice - aciValue) * qty
+		const maturityValueLocal = (nominal + (couponSummary?.leftToPay ?? 0)) * qty
 		const sectorAmountLocal = cleanPrice * qty
 
 		totalBonds += qty
 		totalCoupons += (couponSummary?.leftCouponCount ?? 0) * qty
 		purchaseCostRub += convertToRub(purchaseCostLocal, bondCurrency, rates) ?? 0
 		couponProfitRub += convertToRub(couponProfitLocal, bondCurrency, rates) ?? 0
-		maturityProfitRub += convertToRub(maturityProfitLocal, bondCurrency, rates) ?? 0
+		maturityValueRub += convertToRub(maturityValueLocal, bondCurrency, rates) ?? 0
 
 		const sectorAmountRub = convertToRub(sectorAmountLocal, bondCurrency, rates) ?? 0
 		const sectorKey = typeof bond.sector === "string" && bond.sector ? bond.sector : "other"
@@ -77,9 +77,9 @@ export async function getPortfolioMetrics(
 
 	const normalizedPurchaseCostRub = roundTo(purchaseCostRub) ?? 0
 	const normalizedCouponProfitRub = roundTo(couponProfitRub) ?? 0
-	const normalizedMaturityProfitRub = roundTo(maturityProfitRub) ?? 0
-	const maturityProfitPct = normalizedPurchaseCostRub > 0
-		? roundTo((normalizedMaturityProfitRub / normalizedPurchaseCostRub) * 100) ?? 0
+	const normalizedMaturityValueRub = roundTo(maturityValueRub) ?? 0
+	const maturityValuePct = normalizedPurchaseCostRub > 0
+		? roundTo((normalizedMaturityValueRub / normalizedPurchaseCostRub) * 100) ?? 0
 		: 0
 
 	return {
@@ -89,8 +89,8 @@ export async function getPortfolioMetrics(
 			totalCoupons,
 			purchaseCostRub: normalizedPurchaseCostRub,
 			couponProfitRub: normalizedCouponProfitRub,
-			maturityProfitRub: normalizedMaturityProfitRub,
-			maturityProfitPct,
+			maturityValueRub: normalizedMaturityValueRub,
+			maturityValuePct,
 		},
 		couponSchedule: buildCouponSchedule(scheduleByMonth, now),
 		sectorAllocation: buildSectorAllocation(sectorAmounts),

--- a/server/src/common/getPortfolioMetrics.ts
+++ b/server/src/common/getPortfolioMetrics.ts
@@ -1,0 +1,147 @@
+import moment from "moment"
+import { getCouponSummary, type CouponSummary } from "./getCouponSummary"
+import { convertToRub, type CurrencyRatesSnapshot } from "./getCurrencyRates"
+import { CombinedBondsResponse } from "./interfaces/CombinedBondsResponse"
+import { type BondsDataStatus } from "./interfaces/BondsDataStatus"
+import {
+	type PortfolioCouponScheduleItem,
+	type PortfolioMetricsResponse,
+	type PortfolioPositionInput,
+	type PortfolioSectorAllocationItem,
+} from "./interfaces/PortfolioMetrics"
+import { roundTo } from "./utils/round"
+
+export async function getPortfolioMetrics(
+	positions: PortfolioPositionInput[],
+	bonds: CombinedBondsResponse[],
+	rates: CurrencyRatesSnapshot,
+	bondsStatus: BondsDataStatus,
+	now = moment(),
+): Promise<PortfolioMetricsResponse> {
+	const bondByUid = new Map(bonds.map(bond => [bond.uid, bond]))
+	const scheduleByMonth = new Map<string, number>()
+	const sectorAmounts = new Map<string, number>()
+	let totalBonds = 0
+	let totalCoupons = 0
+	let purchaseCostRub = 0
+	let couponProfitRub = 0
+	let maturityProfitRub = 0
+
+	for (const position of positions) {
+		const qty = Math.max(0, Math.trunc(position.qty))
+		if (qty < 1) {
+			continue
+		}
+
+		const bond = bondByUid.get(position.uid)
+		if (!bond) {
+			continue
+		}
+
+		const couponSummary = await resolveCouponSummary(bond, now)
+		const nominal = bond.nominal ?? 0
+		const aciValue = bond.aciValue ?? 0
+		const bondCurrency = typeof bond.currency === "string" ? bond.currency : undefined
+		const cleanPrice = nominal > 0 && bond.price !== undefined ? (nominal * bond.price) / 100 : 0
+		const purchaseCostLocal = (cleanPrice + aciValue) * qty
+		const couponProfitLocal = (couponSummary?.leftToPay ?? 0) * qty
+		const maturityProfitLocal = (nominal + (couponSummary?.leftToPay ?? 0) - cleanPrice - aciValue) * qty
+		const sectorAmountLocal = cleanPrice * qty
+
+		totalBonds += qty
+		totalCoupons += (couponSummary?.leftCouponCount ?? 0) * qty
+		purchaseCostRub += convertToRub(purchaseCostLocal, bondCurrency, rates) ?? 0
+		couponProfitRub += convertToRub(couponProfitLocal, bondCurrency, rates) ?? 0
+		maturityProfitRub += convertToRub(maturityProfitLocal, bondCurrency, rates) ?? 0
+
+		const sectorAmountRub = convertToRub(sectorAmountLocal, bondCurrency, rates) ?? 0
+		const sectorKey = typeof bond.sector === "string" && bond.sector ? bond.sector : "other"
+		sectorAmounts.set(sectorKey, roundTo((sectorAmounts.get(sectorKey) ?? 0) + sectorAmountRub) ?? 0)
+
+		for (const coupon of couponSummary?.coupons ?? []) {
+			const couponDate = moment(coupon.couponDate)
+			if (!couponDate.isValid()) {
+				continue
+			}
+
+			const monthDiff = couponDate.startOf("month").diff(now.clone().startOf("month"), "months")
+			if (monthDiff < 0 || monthDiff >= 12) {
+				continue
+			}
+
+			const monthKey = couponDate.format("YYYY-MM")
+			const couponAmountRub = convertToRub((coupon.payout ?? 0) * qty, bondCurrency, rates) ?? 0
+			scheduleByMonth.set(monthKey, roundTo((scheduleByMonth.get(monthKey) ?? 0) + couponAmountRub) ?? 0)
+		}
+	}
+
+	const normalizedPurchaseCostRub = roundTo(purchaseCostRub) ?? 0
+	const normalizedCouponProfitRub = roundTo(couponProfitRub) ?? 0
+	const normalizedMaturityProfitRub = roundTo(maturityProfitRub) ?? 0
+	const maturityProfitPct = normalizedPurchaseCostRub > 0
+		? roundTo((normalizedMaturityProfitRub / normalizedPurchaseCostRub) * 100) ?? 0
+		: 0
+
+	return {
+		baseCurrency: "RUB",
+		totals: {
+			totalBonds,
+			totalCoupons,
+			purchaseCostRub: normalizedPurchaseCostRub,
+			couponProfitRub: normalizedCouponProfitRub,
+			maturityProfitRub: normalizedMaturityProfitRub,
+			maturityProfitPct,
+		},
+		couponSchedule: buildCouponSchedule(scheduleByMonth, now),
+		sectorAllocation: buildSectorAllocation(sectorAmounts),
+		actuality: {
+			bondsUpdatedAt: bondsStatus.lastBuildCompletedAt,
+			ratesUpdatedAt: rates.updatedAt,
+			ratesDate: rates.rateDate,
+			generatedAt: now.toISOString(),
+		},
+	}
+}
+
+async function resolveCouponSummary(bond: CombinedBondsResponse, now: moment.Moment): Promise<CouponSummary | undefined> {
+	if (Array.isArray(bond.coupons) && bond.leftToPay !== undefined && bond.leftCouponCount !== undefined) {
+		return {
+			coupons: bond.coupons,
+			leftToPay: bond.leftToPay,
+			leftCouponCount: bond.leftCouponCount,
+			annualCouponSum: bond.couponsYield,
+		}
+	}
+
+	return getCouponSummary(String(bond.figi), Boolean(bond.floatingCouponFlag), now)
+}
+
+function buildCouponSchedule(scheduleByMonth: Map<string, number>, now: moment.Moment): PortfolioCouponScheduleItem[] {
+	const formatter = new Intl.DateTimeFormat("ru-RU", {
+		month: "short",
+		year: "numeric",
+		timeZone: "UTC",
+	})
+
+	return Array.from({ length: 12 }, (_, index) => {
+		const month = now.clone().startOf("month").add(index, "months")
+		const monthKey = month.format("YYYY-MM")
+		return {
+			month: monthKey,
+			label: formatter.format(month.toDate()),
+			amountRub: roundTo(scheduleByMonth.get(monthKey) ?? 0) ?? 0,
+		}
+	})
+}
+
+function buildSectorAllocation(sectorAmounts: Map<string, number>): PortfolioSectorAllocationItem[] {
+	const total = Array.from(sectorAmounts.values()).reduce((sum, amount) => sum + amount, 0)
+
+	return Array.from(sectorAmounts.entries())
+		.map(([sector, amountRub]) => ({
+			sector,
+			amountRub: roundTo(amountRub) ?? 0,
+			sharePct: total > 0 ? roundTo((amountRub / total) * 100) ?? 0 : 0,
+		}))
+		.sort((a, b) => b.amountRub - a.amountRub)
+}

--- a/server/src/common/interfaces/InvestApi.ts
+++ b/server/src/common/interfaces/InvestApi.ts
@@ -50,6 +50,8 @@ export interface GetLastPricesParams {
 
 export interface GetBondCouponsParams {
 	figi: string
+	from?: Date
+	to?: Date
 	instrumentId?: string
 }
 

--- a/server/src/common/interfaces/PortfolioMetrics.ts
+++ b/server/src/common/interfaces/PortfolioMetrics.ts
@@ -1,0 +1,40 @@
+export interface PortfolioPositionInput {
+	uid: string
+	qty: number
+}
+
+export interface PortfolioTotals {
+	totalBonds: number
+	totalCoupons: number
+	purchaseCostRub: number
+	couponProfitRub: number
+	maturityProfitRub: number
+	maturityProfitPct: number
+}
+
+export interface PortfolioCouponScheduleItem {
+	month: string
+	label: string
+	amountRub: number
+}
+
+export interface PortfolioSectorAllocationItem {
+	sector: string
+	amountRub: number
+	sharePct: number
+}
+
+export interface PortfolioActuality {
+	bondsUpdatedAt?: string
+	ratesUpdatedAt: string
+	ratesDate: string
+	generatedAt: string
+}
+
+export interface PortfolioMetricsResponse {
+	baseCurrency: "RUB"
+	totals: PortfolioTotals
+	couponSchedule: PortfolioCouponScheduleItem[]
+	sectorAllocation: PortfolioSectorAllocationItem[]
+	actuality: PortfolioActuality
+}

--- a/server/src/common/interfaces/PortfolioMetrics.ts
+++ b/server/src/common/interfaces/PortfolioMetrics.ts
@@ -8,8 +8,8 @@ export interface PortfolioTotals {
 	totalCoupons: number
 	purchaseCostRub: number
 	couponProfitRub: number
-	maturityProfitRub: number
-	maturityProfitPct: number
+	maturityValueRub: number
+	maturityValuePct: number
 }
 
 export interface PortfolioCouponScheduleItem {

--- a/server/src/common/investApiFacade.test.ts
+++ b/server/src/common/investApiFacade.test.ts
@@ -59,7 +59,12 @@ describe("investApiFacade", () => {
 
 			const result = await facade.getBondCoupons("figi-2")
 
-			expect(getBondCouponsMock).toHaveBeenCalledWith({ figi: "figi-2", instrumentId: "figi-2" })
+			expect(getBondCouponsMock).toHaveBeenCalledWith({
+				figi: "figi-2",
+				from: new Date("2000-01-01T00:00:00.000Z"),
+				to: new Date("2100-01-01T00:00:00.000Z"),
+				instrumentId: "figi-2",
+			})
 			expect(result).toEqual([])
 		})
 })

--- a/server/src/common/investApiFacade.ts
+++ b/server/src/common/investApiFacade.ts
@@ -6,6 +6,9 @@ import {
 	type LastPrice,
 } from "./interfaces/InvestApi"
 
+const COUPON_LOOKUP_FROM = new Date("2000-01-01T00:00:00.000Z")
+const COUPON_LOOKUP_TO = new Date("2100-01-01T00:00:00.000Z")
+
 export async function listBonds(): Promise<ApiBond[]> {
 	const { instruments } = await api.instruments.bonds({
 		instrumentStatus: InstrumentStatus.INSTRUMENT_STATUS_BASE,
@@ -26,6 +29,8 @@ export async function getLastPrices(instrumentIds: string[]): Promise<LastPrice[
 export async function getBondCoupons(figi: string): Promise<ApiCoupon[]> {
 	const { events } = await api.instruments.getBondCoupons({
 		figi,
+		from: COUPON_LOOKUP_FROM,
+		to: COUPON_LOOKUP_TO,
 		instrumentId: figi,
 	})
 	return events || []

--- a/server/src/services/bonds.service.test.ts
+++ b/server/src/services/bonds.service.test.ts
@@ -72,7 +72,12 @@ describe("bonds.service coupons action", () => {
 			meta: {},
 		})
 
-		expect(getBondCouponsMock).toHaveBeenCalledWith({ figi: "figi-1", instrumentId: "figi-1" })
+		expect(getBondCouponsMock).toHaveBeenCalledWith({
+			figi: "figi-1",
+			from: new Date("2000-01-01T00:00:00.000Z"),
+			to: new Date("2100-01-01T00:00:00.000Z"),
+			instrumentId: "figi-1",
+		})
 		expect(result).toHaveLength(2)
 		expect(result.map((coupon: any) => coupon.couponNumber)).toEqual([2, 3])
 		expect(result.map((coupon: any) => coupon.payout)).toEqual([5.5, 7.25])

--- a/server/src/services/bonds.service.test.ts
+++ b/server/src/services/bonds.service.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test"
 
 const getBondCouponsMock = mock(async () => ({ events: [] as any[] }))
+const getOrBuildBondsDataMock = mock(async () => [])
+const getBondsDataStatusMock = mock(async () => ({ isBuilding: false, hasCachedData: true }))
+const ensureBondsDataBuildMock = mock(async () => undefined)
+const getOrRefreshCurrencyRatesMock = mock(async () => ({ baseCurrency: "RUB", rateDate: "20.04.2026", updatedAt: "2026-04-20T04:00:00.000Z", rates: {} }))
+const getPortfolioMetricsMock = mock(async () => ({ baseCurrency: "RUB" }))
 
 mock.module("../common/api", () => ({
 	api: {
@@ -11,9 +16,17 @@ mock.module("../common/api", () => ({
 }))
 
 mock.module("../common/getOrBuildBondsData", () => ({
-	getOrBuildBondsData: mock(async () => []),
-	getBondsDataStatus: mock(async () => ({ isBuilding: false, hasCachedData: true })),
-	ensureBondsDataBuild: mock(async () => undefined),
+	getOrBuildBondsData: getOrBuildBondsDataMock,
+	getBondsDataStatus: getBondsDataStatusMock,
+	ensureBondsDataBuild: ensureBondsDataBuildMock,
+}))
+
+mock.module("../common/getCurrencyRates", () => ({
+	getOrRefreshCurrencyRates: getOrRefreshCurrencyRatesMock,
+}))
+
+mock.module("../common/getPortfolioMetrics", () => ({
+	getPortfolioMetrics: getPortfolioMetricsMock,
 }))
 
 const { default: bondsService } = await import("./bonds.service")
@@ -21,6 +34,16 @@ const { default: bondsService } = await import("./bonds.service")
 describe("bonds.service coupons action", () => {
 	beforeEach(() => {
 		getBondCouponsMock.mockReset()
+		getOrBuildBondsDataMock.mockReset()
+		getBondsDataStatusMock.mockReset()
+		ensureBondsDataBuildMock.mockReset()
+		getOrRefreshCurrencyRatesMock.mockReset()
+		getPortfolioMetricsMock.mockReset()
+		getOrBuildBondsDataMock.mockResolvedValue([])
+		getBondsDataStatusMock.mockResolvedValue({ isBuilding: false, hasCachedData: true })
+		ensureBondsDataBuildMock.mockResolvedValue(undefined)
+		getOrRefreshCurrencyRatesMock.mockResolvedValue({ baseCurrency: "RUB", rateDate: "20.04.2026", updatedAt: "2026-04-20T04:00:00.000Z", rates: {} })
+		getPortfolioMetricsMock.mockResolvedValue({ baseCurrency: "RUB" })
 	})
 
 	test("sorts future coupons and maps payout from payOneBond", async () => {
@@ -71,6 +94,28 @@ describe("bonds.service coupons action", () => {
 
 		expect(result).toHaveLength(2)
 		expect(result.map((coupon: any) => coupon.couponNumber)).toEqual([1, 2])
+	})
+
+	test("delegates portfolio metrics calculation to backend helper", async () => {
+		getOrBuildBondsDataMock.mockResolvedValueOnce([{ uid: "bond-1" }])
+		getBondsDataStatusMock.mockResolvedValueOnce({ isBuilding: false, hasCachedData: true, lastBuildCompletedAt: "2026-04-20T03:00:00.000Z" })
+
+		const result = await bondsService.actions.portfolioMetrics.handler({
+			params: { positions: [{ uid: "bond-1", qty: 2 }] },
+			meta: {},
+		})
+
+		expect(getOrBuildBondsDataMock).toHaveBeenCalledTimes(1)
+		expect(getBondsDataStatusMock).toHaveBeenCalledTimes(1)
+		expect(getOrRefreshCurrencyRatesMock).toHaveBeenCalledTimes(1)
+		expect(getPortfolioMetricsMock).toHaveBeenCalledWith(
+			[{ uid: "bond-1", qty: 2 }],
+			[{ uid: "bond-1" }],
+			{ baseCurrency: "RUB", rateDate: "20.04.2026", updatedAt: "2026-04-20T04:00:00.000Z", rates: {} },
+			{ isBuilding: false, hasCachedData: true, lastBuildCompletedAt: "2026-04-20T03:00:00.000Z" },
+			expect.any(Object),
+		)
+		expect(result).toEqual({ baseCurrency: "RUB" })
 	})
 })
 

--- a/server/src/services/bonds.service.ts
+++ b/server/src/services/bonds.service.ts
@@ -3,6 +3,9 @@ import moment from "moment"
 import { CombinedBondsResponse } from "../common/interfaces/CombinedBondsResponse"
 import { type ApiCoupon } from "../common/interfaces/InvestApi"
 import { type BondsDataStatus } from "../common/interfaces/BondsDataStatus"
+import { type PortfolioPositionInput } from "../common/interfaces/PortfolioMetrics"
+import { getOrRefreshCurrencyRates } from "../common/getCurrencyRates"
+import { getPortfolioMetrics } from "../common/getPortfolioMetrics"
 import { getBondCoupons } from "../common/investApiFacade"
 import { toNumber } from "../common/utils/money"
 import { roundTo } from "../common/utils/round"
@@ -65,6 +68,25 @@ export default {
 					console.error(`[bonds.coupons] Failed to fetch coupons for ${ctx.params.id}:`, err)
 					throw new Error(`Failed to fetch coupons for ${ctx.params.id}`)
 				}
+			},
+		},
+		portfolioMetrics: {
+			params: {
+				positions: {
+					type: "array",
+					items: "object",
+				},
+			},
+			cache: false,
+			async handler(ctx) {
+				const positions = ctx.params.positions as PortfolioPositionInput[]
+				const [bonds, bondsStatus, rates] = await Promise.all([
+					getOrBuildBondsData(),
+					getBondsDataStatus(),
+					getOrRefreshCurrencyRates(),
+				])
+
+				return getPortfolioMetrics(positions, bonds, rates, bondsStatus, moment())
 			},
 		},
 	},

--- a/server/src/services/scheduler.service.test.ts
+++ b/server/src/services/scheduler.service.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test"
+
+const getCachedBondsDataMock = mock(async () => null)
+const getOrBuildBondsDataMock = mock(async () => [])
+const getCachedCurrencyRatesMock = mock(async () => null)
+const refreshCurrencyRatesMock = mock(async () => ({ rates: {} }))
+
+mock.module("../common/getOrBuildBondsData", () => ({
+	getCachedBondsData: getCachedBondsDataMock,
+	getOrBuildBondsData: getOrBuildBondsDataMock,
+}))
+
+mock.module("../common/getCurrencyRates", () => ({
+	getCachedCurrencyRates: getCachedCurrencyRatesMock,
+	refreshCurrencyRates: refreshCurrencyRatesMock,
+}))
+
+const { default: schedulerService } = await import("./scheduler.service")
+
+describe("scheduler.service", () => {
+	beforeEach(() => {
+		getCachedBondsDataMock.mockReset()
+		getOrBuildBondsDataMock.mockReset()
+		getCachedCurrencyRatesMock.mockReset()
+		refreshCurrencyRatesMock.mockReset()
+		getCachedBondsDataMock.mockResolvedValue(null)
+		getOrBuildBondsDataMock.mockResolvedValue([])
+		getCachedCurrencyRatesMock.mockResolvedValue(null)
+		refreshCurrencyRatesMock.mockResolvedValue({ rates: {} })
+	})
+
+	test("triggers initial jobs when caches are empty", async () => {
+		const [bondsCron, ratesCron] = schedulerService.crons
+
+		await bondsCron.runOnInit()
+		await ratesCron.runOnInit()
+
+		expect(getCachedBondsDataMock).toHaveBeenCalledTimes(1)
+		expect(getOrBuildBondsDataMock).toHaveBeenCalledWith(true)
+		expect(getCachedCurrencyRatesMock).toHaveBeenCalledTimes(1)
+		expect(refreshCurrencyRatesMock).toHaveBeenCalledTimes(1)
+		expect(ratesCron.timeZone).toBe("Europe/Moscow")
+		expect(ratesCron.cronTime).toBe("0 7,12,17 * * *")
+	})
+
+	test("skips initial refresh when caches already exist", async () => {
+		const [bondsCron, ratesCron] = schedulerService.crons
+		getCachedBondsDataMock.mockResolvedValueOnce([{ figi: "cached" }])
+		getCachedCurrencyRatesMock.mockResolvedValueOnce({ rates: { USD: { rate: 80 } } })
+
+		await bondsCron.runOnInit()
+		await ratesCron.runOnInit()
+
+		expect(getOrBuildBondsDataMock).not.toHaveBeenCalled()
+		expect(refreshCurrencyRatesMock).not.toHaveBeenCalled()
+	})
+})

--- a/server/src/services/scheduler.service.ts
+++ b/server/src/services/scheduler.service.ts
@@ -1,6 +1,9 @@
 import Cron from "moleculer-cron"
+import { getCachedCurrencyRates, refreshCurrencyRates } from "../common/getCurrencyRates"
 import { getCachedBondsData, getOrBuildBondsData } from "../common/getOrBuildBondsData"
+
 let isDataGrabberRunning = false
+let isCurrencyRatesRefreshRunning = false
 
 async function runDataGrabber(reason: "tick" | "init") {
   if (isDataGrabberRunning) {
@@ -13,6 +16,20 @@ async function runDataGrabber(reason: "tick" | "init") {
     await getOrBuildBondsData(true)
   } finally {
     isDataGrabberRunning = false
+  }
+}
+
+async function runCurrencyRatesRefresh(reason: "tick" | "init") {
+  if (isCurrencyRatesRefreshRunning) {
+    console.warn(`[CurrencyRates] skip ${reason}; previous job is still running`)
+    return
+  }
+
+  isCurrencyRatesRefreshRunning = true
+  try {
+    await refreshCurrencyRates()
+  } finally {
+    isCurrencyRatesRefreshRunning = false
   }
 }
 
@@ -43,6 +60,28 @@ export default {
         }
       },
       timeZone: "GMT",
+    },
+    {
+      name: "CurrencyRatesRefresh",
+      cronTime: "0 7,12,17 * * *",
+      onTick: async () => {
+        try {
+          await runCurrencyRatesRefresh("tick")
+        } catch (err) {
+          console.error("[CurrencyRates] onTick failed:", err?.message ?? err)
+        }
+      },
+      runOnInit: async () => {
+        const rates = await getCachedCurrencyRates()
+        if (!rates) {
+          try {
+            await runCurrencyRatesRefresh("init")
+          } catch (err) {
+            console.error("[CurrencyRates] runOnInit failed:", err?.message ?? err)
+          }
+        }
+      },
+      timeZone: "Europe/Moscow",
     },
   ],
 }


### PR DESCRIPTION
## Summary
- перенести расчет метрик портфеля на backend, добавить кеш курсов ЦБ РФ и endpoint с агрегированной аналитикой
- исправить расчет суммы при погашении и запрашивать полный график купонов для корректного учета всех выплат
- обновить UI раздела `Подобранный портфель`: округление, дата актуальности, график купонов на год и диаграмма по секторам

## Testing
- bun run lint
- bun run test
- bun run build