### PR TITLE
feat(portfolio): обновить метрики и графики портфеля

### DIFF
--- a/UI/bun.lock
+++ b/UI/bun.lock
@@ -13,7 +13,6 @@
         "pinia": "^2.1.7",
         "vue": "^3.3.8",
         "vue-axios": "^3.5.2",
-        "vue-echarts": "^8.0.1",
         "vue-router": "^5.0.4",
       },
       "devDependencies": {
@@ -906,8 +905,6 @@
     "vue-axios": ["vue-axios@3.5.2", "", { "peerDependencies": { "axios": "1.13.6", "vue": "3.5.29" } }, "sha512-GP+dct7UlAWkl1qoP3ppw0z6jcSua5/IrMpjB5O8bh089iIiJ+hdxPYH2NPEpajlYgkW5EVMP95ttXWdas1O0g=="],
 
     "vue-demi": ["vue-demi@0.14.10", "", { "peerDependencies": { "vue": "3.5.29" }, "bin": { "vue-demi-fix": "bin/vue-demi-fix.js", "vue-demi-switch": "bin/vue-demi-switch.js" } }, "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg=="],
-
-    "vue-echarts": ["vue-echarts@8.0.1", "", { "peerDependencies": { "echarts": "^6.0.0", "vue": "^3.3.0" } }, "sha512-23rJTFLu1OUEGRWjJGmdGt8fP+8+ja1gVgzMYPIPaHWpXegcO1viIAaeu2H4QHESlVeHzUAHIxKXGrwjsyXAaA=="],
 
     "vue-eslint-parser": ["vue-eslint-parser@9.4.3", "", { "dependencies": { "debug": "4.4.3", "eslint-scope": "7.2.2", "eslint-visitor-keys": "3.4.3", "espree": "9.6.1", "esquery": "1.7.0", "lodash": "4.17.23", "semver": "7.7.4" }, "peerDependencies": { "eslint": "8.57.1" } }, "sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg=="],
 

--- a/UI/bun.lock
+++ b/UI/bun.lock
@@ -7,11 +7,13 @@
       "dependencies": {
         "@vueuse/core": "^10.6.1",
         "axios": "^1.15.0",
+        "echarts": "^6.0.0",
         "moment": "^2.29.4",
         "ms": "3.0.0-canary.1",
         "pinia": "^2.1.7",
         "vue": "^3.3.8",
         "vue-axios": "^3.5.2",
+        "vue-echarts": "^8.0.1",
         "vue-router": "^5.0.4",
       },
       "devDependencies": {
@@ -396,6 +398,8 @@
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "2.0.3" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "1.0.2", "es-errors": "1.3.0", "gopd": "1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "echarts": ["echarts@6.0.0", "", { "dependencies": { "tslib": "2.3.0", "zrender": "6.0.0" } }, "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ=="],
 
@@ -859,7 +863,7 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
-    "tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
+    "tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
 
     "tsutils": ["tsutils@3.21.0", "", { "dependencies": { "tslib": "1.14.1" }, "peerDependencies": { "typescript": "5.0.4" } }, "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA=="],
 
@@ -903,6 +907,8 @@
 
     "vue-demi": ["vue-demi@0.14.10", "", { "peerDependencies": { "vue": "3.5.29" }, "bin": { "vue-demi-fix": "bin/vue-demi-fix.js", "vue-demi-switch": "bin/vue-demi-switch.js" } }, "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg=="],
 
+    "vue-echarts": ["vue-echarts@8.0.1", "", { "peerDependencies": { "echarts": "^6.0.0", "vue": "^3.3.0" } }, "sha512-23rJTFLu1OUEGRWjJGmdGt8fP+8+ja1gVgzMYPIPaHWpXegcO1viIAaeu2H4QHESlVeHzUAHIxKXGrwjsyXAaA=="],
+
     "vue-eslint-parser": ["vue-eslint-parser@9.4.3", "", { "dependencies": { "debug": "4.4.3", "eslint-scope": "7.2.2", "eslint-visitor-keys": "3.4.3", "espree": "9.6.1", "esquery": "1.7.0", "lodash": "4.17.23", "semver": "7.7.4" }, "peerDependencies": { "eslint": "8.57.1" } }, "sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg=="],
 
     "vue-router": ["vue-router@5.0.4", "", { "dependencies": { "@babel/generator": "^7.28.6", "@vue-macros/common": "^3.1.1", "@vue/devtools-api": "^8.0.6", "ast-walker-scope": "^0.8.3", "chokidar": "^5.0.0", "json5": "^2.2.3", "local-pkg": "^1.1.2", "magic-string": "^0.30.21", "mlly": "^1.8.0", "muggle-string": "^0.4.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "scule": "^1.3.0", "tinyglobby": "^0.2.15", "unplugin": "^3.0.0", "unplugin-utils": "^0.3.1", "yaml": "^2.8.2" }, "peerDependencies": { "@pinia/colada": ">=0.21.2", "@vue/compiler-sfc": "^3.5.17", "pinia": "^3.0.4", "vue": "^3.5.0" }, "optionalPeers": ["@pinia/colada", "@vue/compiler-sfc", "pinia"] }, "sha512-lCqDLCI2+fKVRl2OzXuzdSWmxXFLQRxQbmHugnRpTMyYiT+hNaycV0faqG5FBHDXoYrZ6MQcX87BvbY8mQ20Bg=="],
@@ -932,6 +938,8 @@
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zrender": ["zrender@6.0.0", "", { "dependencies": { "tslib": "2.3.0" } }, "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -982,6 +990,8 @@
     "npm-run-all/cross-spawn": ["cross-spawn@6.0.6", "", { "dependencies": { "nice-try": "1.0.5", "path-key": "2.0.1", "semver": "5.7.2", "shebang-command": "1.2.0", "which": "1.3.1" } }, "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw=="],
 
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "tsutils/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "unplugin-vue-components/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 

--- a/UI/package.json
+++ b/UI/package.json
@@ -25,7 +25,6 @@
     "pinia": "^2.1.7",
     "vue": "^3.3.8",
     "vue-axios": "^3.5.2",
-    "vue-echarts": "^8.0.1",
     "vue-router": "^5.0.4"
   },
   "devDependencies": {

--- a/UI/package.json
+++ b/UI/package.json
@@ -19,11 +19,13 @@
   "dependencies": {
     "@vueuse/core": "^10.6.1",
     "axios": "^1.15.0",
+    "echarts": "^6.0.0",
     "moment": "^2.29.4",
     "ms": "3.0.0-canary.1",
     "pinia": "^2.1.7",
     "vue": "^3.3.8",
     "vue-axios": "^3.5.2",
+    "vue-echarts": "^8.0.1",
     "vue-router": "^5.0.4"
   },
   "devDependencies": {

--- a/UI/src/components/PortfolioCouponChart.vue
+++ b/UI/src/components/PortfolioCouponChart.vue
@@ -2,53 +2,118 @@
 	<div class="space-y-4 rounded-box border border-base-300 bg-base-100 p-4">
 		<div class="flex items-center justify-between gap-3">
 			<h3 class="text-base font-semibold text-base-content">Купоны на ближайший год</h3>
-			<span class="text-xs text-base-content/60">Сумма по месяцам, RUB</span>
+			<span class="text-xs text-base-content/60">Итого: {{ formatMoney(totalCouponsRub) }}</span>
 		</div>
 
 		<div v-if="items.length < 1" class="rounded-box bg-base-200 px-4 py-6 text-sm text-base-content/70">
 			Нет данных по купонам.
 		</div>
 
-		<div v-else class="grid grid-cols-12 gap-2">
-			<div
-				v-for="item in items"
-				:key="item.month"
-				class="flex min-w-0 flex-col items-center gap-2"
-			>
-				<div class="flex h-36 w-full items-end rounded-box bg-base-200 px-1 py-2">
-					<div
-						class="w-full rounded-t-md bg-primary transition-all"
-						:style="{ height: `${getBarHeight(item.amountRub)}%` }"
-					></div>
-				</div>
-				<div class="text-center text-[11px] leading-tight text-base-content/70">{{ shortLabel(item.label) }}</div>
-				<div class="text-center text-[11px] font-medium text-base-content">{{ formatMoney(item.amountRub) }}</div>
-			</div>
+		<div v-else class="overflow-hidden rounded-box bg-base-200 p-2">
+			<v-chart :option="chartOption" autoresize class="h-80 w-full" />
 		</div>
 	</div>
 </template>
 
 <script lang="ts" setup>
 import { computed, type PropType } from "vue"
+import { use } from "echarts/core"
+import { BarChart } from "echarts/charts"
+import { GridComponent, TooltipComponent } from "echarts/components"
+import { CanvasRenderer } from "echarts/renderers"
+import VChart from "vue-echarts"
 import type { PortfolioCouponScheduleItem } from "@/data/Interfaces/PortfolioMetrics"
 import { formatMoney } from "@/utils/format"
+
+use([CanvasRenderer, BarChart, GridComponent, TooltipComponent])
+
+const compactNumberFormatter = new Intl.NumberFormat("ru-RU", {
+	maximumFractionDigits: 0,
+})
 
 const props = defineProps({
 	items: {
 		type: Array as PropType<PortfolioCouponScheduleItem[]>,
-		default: () => []
-	}
+		default: () => [],
+	},
 })
 
-const maxAmount = computed(() => Math.max(...props.items.map(item => item.amountRub), 0))
-
-const getBarHeight = (amount: number) => {
-	if (maxAmount.value <= 0) {
-		return 0
-	}
-
-	return Math.max(4, Math.round((amount / maxAmount.value) * 100))
-}
+const totalCouponsRub = computed(() => props.items.reduce((sum, item) => sum + item.amountRub, 0))
 
 const shortLabel = (label: string) => label.replace(/\s+\d{4}\s*г\.?$/u, "")
+
+const chartOption = computed(() => ({
+	animation: false,
+	grid: {
+		left: 8,
+		right: 8,
+		top: 12,
+		bottom: 8,
+		containLabel: true,
+	},
+	xAxis: {
+		type: "category",
+		data: props.items.map(item => shortLabel(item.label)),
+		axisTick: {
+			show: false,
+		},
+		axisLine: {
+			lineStyle: {
+				color: "rgba(148, 163, 184, 0.35)",
+			},
+		},
+		axisLabel: {
+			color: "rgba(15, 23, 42, 0.7)",
+			fontSize: 11,
+		},
+	},
+	yAxis: {
+		type: "value",
+		splitNumber: 4,
+		axisLabel: {
+			color: "rgba(15, 23, 42, 0.7)",
+			formatter: (value: number) => compactNumberFormatter.format(value),
+		},
+		splitLine: {
+			lineStyle: {
+				color: "rgba(148, 163, 184, 0.2)",
+			},
+		},
+	},
+	tooltip: {
+		trigger: "axis",
+		axisPointer: {
+			type: "shadow",
+		},
+		backgroundColor: "rgba(15, 23, 42, 0.92)",
+		borderWidth: 0,
+		textStyle: {
+			color: "#f8fafc",
+		},
+		formatter: (params: { dataIndex: number }[]) => {
+			const item = props.items[params[0]?.dataIndex ?? 0]
+			if (!item) {
+				return ""
+			}
+
+			return item.label + "<br/>" + formatMoney(item.amountRub)
+		},
+	},
+	series: [
+		{
+			type: "bar",
+			data: props.items.map(item => item.amountRub),
+			barMaxWidth: 28,
+			itemStyle: {
+				color: "#2563eb",
+				borderRadius: [8, 8, 0, 0],
+			},
+			emphasis: {
+				itemStyle: {
+					color: "#1d4ed8",
+				},
+			},
+		},
+	],
+}))
 </script>

--- a/UI/src/components/PortfolioCouponChart.vue
+++ b/UI/src/components/PortfolioCouponChart.vue
@@ -9,19 +9,16 @@
 			Нет данных по купонам.
 		</div>
 
-		<div v-else class="overflow-hidden rounded-box bg-base-200 p-2">
-			<v-chart :option="chartOption" autoresize class="h-80 w-full" />
-		</div>
+		<div v-else ref="chartElement" class="h-80 w-full rounded-box bg-base-200 p-2"></div>
 	</div>
 </template>
 
 <script lang="ts" setup>
-import { computed, type PropType } from "vue"
-import { use } from "echarts/core"
+import { computed, onBeforeUnmount, onMounted, ref, watch, type PropType } from "vue"
 import { BarChart } from "echarts/charts"
 import { GridComponent, TooltipComponent } from "echarts/components"
+import { init, use, type EChartsType } from "echarts/core"
 import { CanvasRenderer } from "echarts/renderers"
-import VChart from "vue-echarts"
 import type { PortfolioCouponScheduleItem } from "@/data/Interfaces/PortfolioMetrics"
 import { formatMoney } from "@/utils/format"
 
@@ -38,82 +35,94 @@ const props = defineProps({
 	},
 })
 
+const chartElement = ref<HTMLDivElement | null>(null)
 const totalCouponsRub = computed(() => props.items.reduce((sum, item) => sum + item.amountRub, 0))
+
+let chart: EChartsType | undefined
+let resizeObserver: ResizeObserver | undefined
 
 const shortLabel = (label: string) => label.replace(/\s+\d{4}\s*г\.?$/u, "")
 
-const chartOption = computed(() => ({
-	animation: false,
-	grid: {
-		left: 8,
-		right: 8,
-		top: 12,
-		bottom: 8,
-		containLabel: true,
-	},
-	xAxis: {
-		type: "category",
-		data: props.items.map(item => shortLabel(item.label)),
-		axisTick: {
-			show: false,
-		},
-		axisLine: {
-			lineStyle: {
-				color: "rgba(148, 163, 184, 0.35)",
-			},
-		},
-		axisLabel: {
-			color: "rgba(15, 23, 42, 0.7)",
-			fontSize: 11,
-		},
-	},
-	yAxis: {
-		type: "value",
-		splitNumber: 4,
-		axisLabel: {
-			color: "rgba(15, 23, 42, 0.7)",
-			formatter: (value: number) => compactNumberFormatter.format(value),
-		},
-		splitLine: {
-			lineStyle: {
-				color: "rgba(148, 163, 184, 0.2)",
-			},
-		},
-	},
-	tooltip: {
-		trigger: "axis",
-		axisPointer: {
-			type: "shadow",
-		},
-		backgroundColor: "rgba(15, 23, 42, 0.92)",
-		borderWidth: 0,
-		textStyle: {
-			color: "#f8fafc",
-		},
-		formatter: (params: { dataIndex: number }[]) => {
-			const item = props.items[params[0]?.dataIndex ?? 0]
-			if (!item) {
-				return ""
-			}
+const renderChart = () => {
+	if (!chartElement.value) {
+		return
+	}
 
-			return item.label + "<br/>" + formatMoney(item.amountRub)
+	if (!chart) {
+		chart = init(chartElement.value)
+	}
+
+	chart.setOption({
+		animation: false,
+		grid: {
+			left: 8,
+			right: 8,
+			top: 12,
+			bottom: 8,
+			containLabel: true,
 		},
-	},
-	series: [
-		{
-			type: "bar",
-			data: props.items.map(item => item.amountRub),
-			barMaxWidth: 28,
-			itemStyle: {
-				color: "#2563eb",
-				borderRadius: [8, 8, 0, 0],
+		xAxis: {
+			type: "category",
+			data: props.items.map(item => shortLabel(item.label)),
+			axisTick: { show: false },
+			axisLine: { lineStyle: { color: "rgba(148, 163, 184, 0.35)" } },
+			axisLabel: {
+				color: "rgba(15, 23, 42, 0.7)",
+				fontSize: 11,
 			},
-			emphasis: {
+		},
+		yAxis: {
+			type: "value",
+			splitNumber: 4,
+			axisLabel: {
+				color: "rgba(15, 23, 42, 0.7)",
+				formatter: (value: number) => compactNumberFormatter.format(value),
+			},
+			splitLine: {
+				lineStyle: { color: "rgba(148, 163, 184, 0.2)" },
+			},
+		},
+		tooltip: {
+			trigger: "axis",
+			axisPointer: { type: "shadow" },
+			backgroundColor: "rgba(15, 23, 42, 0.92)",
+			borderWidth: 0,
+			textStyle: { color: "#f8fafc" },
+			formatter: (params: { dataIndex: number }[]) => {
+				const item = props.items[params[0]?.dataIndex ?? 0]
+				return item ? item.label + "<br/>" + formatMoney(item.amountRub) : ""
+			},
+		},
+		series: [
+			{
+				type: "bar",
+				data: props.items.map(item => item.amountRub),
+				barMaxWidth: 28,
 				itemStyle: {
-					color: "#1d4ed8",
+					color: "#2563eb",
+					borderRadius: [8, 8, 0, 0],
+				},
+				emphasis: {
+					itemStyle: { color: "#1d4ed8" },
 				},
 			},
-		},
-	],
-}))
+		],
+	})
+}
+
+onMounted(() => {
+	renderChart()
+
+	if (chartElement.value) {
+		resizeObserver = new ResizeObserver(() => chart?.resize())
+		resizeObserver.observe(chartElement.value)
+	}
+})
+
+watch(() => props.items, renderChart, { deep: true })
+
+onBeforeUnmount(() => {
+	resizeObserver?.disconnect()
+	chart?.dispose()
+})
 </script>

--- a/UI/src/components/PortfolioCouponChart.vue
+++ b/UI/src/components/PortfolioCouponChart.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onBeforeUnmount, onMounted, ref, watch, type PropType } from "vue"
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch, type PropType } from "vue"
 import { BarChart } from "echarts/charts"
 import { GridComponent, TooltipComponent } from "echarts/components"
 import { init, use, type EChartsType } from "echarts/core"
@@ -40,8 +40,23 @@ const totalCouponsRub = computed(() => props.items.reduce((sum, item) => sum + i
 
 let chart: EChartsType | undefined
 let resizeObserver: ResizeObserver | undefined
+let themeObserver: MutationObserver | undefined
 
 const shortLabel = (label: string) => label.replace(/\s+\d{4}\s*г\.?$/u, "")
+
+const getThemePalette = () => {
+	const isDark = document.documentElement.getAttribute("data-theme") === "dracula"
+
+	return {
+		axisText: isDark ? "rgba(248, 250, 252, 0.7)" : "rgba(15, 23, 42, 0.7)",
+		axisLine: isDark ? "rgba(148, 163, 184, 0.35)" : "rgba(148, 163, 184, 0.35)",
+		splitLine: isDark ? "rgba(148, 163, 184, 0.18)" : "rgba(148, 163, 184, 0.2)",
+		bar: isDark ? "#f472b6" : "#2563eb",
+		barHover: isDark ? "#ec4899" : "#1d4ed8",
+		tooltipBg: isDark ? "rgba(15, 23, 42, 0.94)" : "rgba(15, 23, 42, 0.92)",
+		tooltipText: "#f8fafc",
+	}
+}
 
 const renderChart = () => {
 	if (!chartElement.value) {
@@ -51,6 +66,8 @@ const renderChart = () => {
 	if (!chart) {
 		chart = init(chartElement.value)
 	}
+
+	const palette = getThemePalette()
 
 	chart.setOption({
 		animation: false,
@@ -65,9 +82,9 @@ const renderChart = () => {
 			type: "category",
 			data: props.items.map(item => shortLabel(item.label)),
 			axisTick: { show: false },
-			axisLine: { lineStyle: { color: "rgba(148, 163, 184, 0.35)" } },
+			axisLine: { lineStyle: { color: palette.axisLine } },
 			axisLabel: {
-				color: "rgba(15, 23, 42, 0.7)",
+				color: palette.axisText,
 				fontSize: 11,
 			},
 		},
@@ -75,19 +92,19 @@ const renderChart = () => {
 			type: "value",
 			splitNumber: 4,
 			axisLabel: {
-				color: "rgba(15, 23, 42, 0.7)",
+				color: palette.axisText,
 				formatter: (value: number) => compactNumberFormatter.format(value),
 			},
 			splitLine: {
-				lineStyle: { color: "rgba(148, 163, 184, 0.2)" },
+				lineStyle: { color: palette.splitLine },
 			},
 		},
 		tooltip: {
 			trigger: "axis",
 			axisPointer: { type: "shadow" },
-			backgroundColor: "rgba(15, 23, 42, 0.92)",
+			backgroundColor: palette.tooltipBg,
 			borderWidth: 0,
-			textStyle: { color: "#f8fafc" },
+			textStyle: { color: palette.tooltipText },
 			formatter: (params: { dataIndex: number }[]) => {
 				const item = props.items[params[0]?.dataIndex ?? 0]
 				return item ? item.label + "<br/>" + formatMoney(item.amountRub) : ""
@@ -99,30 +116,40 @@ const renderChart = () => {
 				data: props.items.map(item => item.amountRub),
 				barMaxWidth: 28,
 				itemStyle: {
-					color: "#2563eb",
+					color: palette.bar,
 					borderRadius: [8, 8, 0, 0],
 				},
 				emphasis: {
-					itemStyle: { color: "#1d4ed8" },
+					itemStyle: { color: palette.barHover },
 				},
 			},
 		],
 	})
+
+	chart.resize()
 }
 
-onMounted(() => {
+onMounted(async () => {
+	await nextTick()
 	renderChart()
 
 	if (chartElement.value) {
 		resizeObserver = new ResizeObserver(() => chart?.resize())
 		resizeObserver.observe(chartElement.value)
 	}
+
+	themeObserver = new MutationObserver(() => renderChart())
+	themeObserver.observe(document.documentElement, {
+		attributes: true,
+		attributeFilter: ["data-theme"],
+	})
 })
 
-watch(() => props.items, renderChart, { deep: true })
+watch(() => props.items, () => renderChart(), { deep: true })
 
 onBeforeUnmount(() => {
 	resizeObserver?.disconnect()
+	themeObserver?.disconnect()
 	chart?.dispose()
 })
 </script>

--- a/UI/src/components/PortfolioSectorChart.vue
+++ b/UI/src/components/PortfolioSectorChart.vue
@@ -10,16 +10,8 @@
 		</div>
 
 		<div v-else class="grid gap-4 md:grid-cols-[12rem_minmax(0,1fr)] md:items-center">
-			<div
-				class="mx-auto h-48 w-48 rounded-full border border-base-300"
-				:style="{ background: chartGradient }"
-			>
-				<div class="mx-auto mt-10 flex h-28 w-28 items-center justify-center rounded-full bg-base-100 text-center text-xs text-base-content/70">
-					<div>
-						<div class="font-semibold text-base-content">{{ formatMoney(totalAmount) }}</div>
-						<div>Всего</div>
-					</div>
-				</div>
+			<div class="mx-auto h-48 w-full max-w-48 overflow-hidden rounded-full bg-base-200">
+				<v-chart :option="chartOption" autoresize class="h-48 w-48" />
 			</div>
 
 			<div class="space-y-2">
@@ -44,31 +36,85 @@
 
 <script lang="ts" setup>
 import { computed, type PropType } from "vue"
+import { PieChart } from "echarts/charts"
+import { TooltipComponent } from "echarts/components"
+import { use } from "echarts/core"
+import { CanvasRenderer } from "echarts/renderers"
+import VChart from "vue-echarts"
 import SectorsCollation from "@/data/collations/SectorsCollation"
 import type { PortfolioSectorAllocationItem } from "@/data/Interfaces/PortfolioMetrics"
 import { formatMoney, formatPercent } from "@/utils/format"
+
+use([CanvasRenderer, PieChart, TooltipComponent])
 
 const colors = ["#2563eb", "#7c3aed", "#ea580c", "#059669", "#dc2626", "#ca8a04", "#0f766e", "#9333ea"]
 
 const props = defineProps({
 	items: {
 		type: Array as PropType<PortfolioSectorAllocationItem[]>,
-		default: () => []
-	}
+		default: () => [],
+	},
 })
 
 const totalAmount = computed(() => props.items.reduce((sum, item) => sum + item.amountRub, 0))
 
-const chartGradient = computed(() => {
-	if (props.items.length < 1) {
-		return "conic-gradient(var(--color-base-300) 0deg 360deg)"
-	}
-
-	let currentAngle = 0
-	return `conic-gradient(${props.items.map((item, index) => {
-			const start = currentAngle
-			currentAngle += (item.sharePct / 100) * 360
-			return `${colors[index % colors.length]} ${start}deg ${currentAngle}deg`
-		}).join(", ")})`
-})
+const chartOption = computed(() => ({
+	animation: false,
+	tooltip: {
+		trigger: "item",
+		backgroundColor: "rgba(15, 23, 42, 0.92)",
+		borderWidth: 0,
+		textStyle: {
+			color: "#f8fafc",
+		},
+		formatter: (params: { data: { amountRub: number; sharePct: number }; name: string }) => {
+			return [params.name, formatMoney(params.data.amountRub), formatPercent(params.data.sharePct)].join("<br/>")
+		},
+	},
+	graphic: [
+		{
+			type: "text",
+			left: "center",
+			top: "40%",
+			style: {
+				text: formatMoney(totalAmount.value),
+				textAlign: "center",
+				fill: "#0f172a",
+				fontSize: 15,
+				fontWeight: 600,
+			},
+		},
+		{
+			type: "text",
+			left: "center",
+			top: "54%",
+			style: {
+				text: "Всего",
+				textAlign: "center",
+				fill: "rgba(15, 23, 42, 0.7)",
+				fontSize: 12,
+			},
+		},
+	],
+	series: [
+		{
+			type: "pie",
+			radius: ["58%", "82%"],
+			avoidLabelOverlap: false,
+			label: { show: false },
+			labelLine: { show: false },
+			itemStyle: {
+				borderColor: "#ffffff",
+				borderWidth: 3,
+			},
+			data: props.items.map((item, index) => ({
+				value: item.amountRub,
+				name: SectorsCollation.getLabel(item.sector),
+				amountRub: item.amountRub,
+				sharePct: item.sharePct,
+				itemStyle: { color: colors[index % colors.length] },
+			})),
+		},
+	],
+}))
 </script>

--- a/UI/src/components/PortfolioSectorChart.vue
+++ b/UI/src/components/PortfolioSectorChart.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onBeforeUnmount, onMounted, ref, watch, type PropType } from "vue"
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch, type PropType } from "vue"
 import { PieChart } from "echarts/charts"
 import { GraphicComponent, TooltipComponent } from "echarts/components"
 import { init, use, type EChartsType } from "echarts/core"
@@ -25,7 +25,8 @@ import { formatMoney, formatPercent } from "@/utils/format"
 
 use([CanvasRenderer, PieChart, GraphicComponent, TooltipComponent])
 
-const colors = ["#2563eb", "#7c3aed", "#ea580c", "#059669", "#dc2626", "#ca8a04", "#0f766e", "#9333ea"]
+const lightColors = ["#2563eb", "#7c3aed", "#ea580c", "#059669", "#dc2626", "#ca8a04", "#0f766e", "#9333ea"]
+const darkColors = ["#f472b6", "#c084fc", "#fb923c", "#34d399", "#f87171", "#facc15", "#2dd4bf", "#a78bfa"]
 
 const props = defineProps({
 	items: {
@@ -39,6 +40,20 @@ const totalAmount = computed(() => props.items.reduce((sum, item) => sum + item.
 
 let chart: EChartsType | undefined
 let resizeObserver: ResizeObserver | undefined
+let themeObserver: MutationObserver | undefined
+
+const getThemePalette = () => {
+	const isDark = document.documentElement.getAttribute("data-theme") === "dracula"
+
+	return {
+		text: isDark ? "#f8fafc" : "#0f172a",
+		subtleText: isDark ? "rgba(248, 250, 252, 0.7)" : "rgba(15, 23, 42, 0.7)",
+		tooltipBg: isDark ? "rgba(15, 23, 42, 0.94)" : "rgba(15, 23, 42, 0.92)",
+		tooltipText: "#f8fafc",
+		border: isDark ? "#282a36" : "#f8fafc",
+		colors: isDark ? darkColors : lightColors,
+	}
+}
 
 const renderChart = () => {
 	if (!chartElement.value) {
@@ -49,13 +64,15 @@ const renderChart = () => {
 		chart = init(chartElement.value)
 	}
 
+	const palette = getThemePalette()
+
 	chart.setOption({
 		animation: false,
 		tooltip: {
 			trigger: "item",
-			backgroundColor: "rgba(15, 23, 42, 0.92)",
+			backgroundColor: palette.tooltipBg,
 			borderWidth: 0,
-			textStyle: { color: "#f8fafc" },
+			textStyle: { color: palette.tooltipText },
 			formatter: (params: { data: { amountRub: number; sharePct: number }; name: string }) => {
 				return [params.name, formatMoney(params.data.amountRub), formatPercent(params.data.sharePct)].join("<br/>")
 			},
@@ -68,7 +85,7 @@ const renderChart = () => {
 				style: {
 					text: formatMoney(totalAmount.value),
 					textAlign: "center",
-					fill: "#0f172a",
+					fill: palette.text,
 					fontSize: 15,
 					fontWeight: 600,
 				},
@@ -80,7 +97,7 @@ const renderChart = () => {
 				style: {
 					text: "Всего",
 					textAlign: "center",
-					fill: "rgba(15, 23, 42, 0.7)",
+					fill: palette.subtleText,
 					fontSize: 12,
 				},
 			},
@@ -93,7 +110,7 @@ const renderChart = () => {
 				label: { show: false },
 				labelLine: { show: false },
 				itemStyle: {
-					borderColor: "#f8fafc",
+					borderColor: palette.border,
 					borderWidth: 3,
 				},
 				data: props.items.map((item, index) => ({
@@ -101,26 +118,36 @@ const renderChart = () => {
 					name: SectorsCollation.getLabel(item.sector),
 					amountRub: item.amountRub,
 					sharePct: item.sharePct,
-					itemStyle: { color: colors[index % colors.length] },
+					itemStyle: { color: palette.colors[index % palette.colors.length] },
 				})),
 			},
 		],
 	})
+
+	chart.resize()
 }
 
-onMounted(() => {
+onMounted(async () => {
+	await nextTick()
 	renderChart()
 
 	if (chartElement.value) {
 		resizeObserver = new ResizeObserver(() => chart?.resize())
 		resizeObserver.observe(chartElement.value)
 	}
+
+	themeObserver = new MutationObserver(() => renderChart())
+	themeObserver.observe(document.documentElement, {
+		attributes: true,
+		attributeFilter: ["data-theme"],
+	})
 })
 
-watch(() => props.items, renderChart, { deep: true })
+watch(() => props.items, () => renderChart(), { deep: true })
 
 onBeforeUnmount(() => {
 	resizeObserver?.disconnect()
+	themeObserver?.disconnect()
 	chart?.dispose()
 })
 </script>

--- a/UI/src/components/PortfolioSectorChart.vue
+++ b/UI/src/components/PortfolioSectorChart.vue
@@ -9,43 +9,21 @@
 			Нет данных по секторам.
 		</div>
 
-		<div v-else class="grid gap-4 md:grid-cols-[12rem_minmax(0,1fr)] md:items-center">
-			<div class="mx-auto h-48 w-full max-w-48 overflow-hidden rounded-full bg-base-200">
-				<v-chart :option="chartOption" autoresize class="h-48 w-48" />
-			</div>
-
-			<div class="space-y-2">
-				<div
-					v-for="(item, index) in items"
-					:key="item.sector"
-					class="flex items-start justify-between gap-3 rounded-box bg-base-200 px-3 py-2 text-sm"
-				>
-					<div class="flex min-w-0 items-start gap-2">
-						<span class="mt-1 h-3 w-3 shrink-0 rounded-full" :style="{ backgroundColor: colors[index % colors.length] }"></span>
-						<span class="truncate">{{ SectorsCollation.getLabel(item.sector) }}</span>
-					</div>
-					<div class="shrink-0 text-right">
-						<div class="font-medium text-base-content">{{ formatMoney(item.amountRub) }}</div>
-						<div class="text-xs text-base-content/70">{{ formatPercent(item.sharePct) }}</div>
-					</div>
-				</div>
-			</div>
-		</div>
+		<div v-else ref="chartElement" class="h-80 w-full rounded-box bg-base-200"></div>
 	</div>
 </template>
 
 <script lang="ts" setup>
-import { computed, type PropType } from "vue"
+import { computed, onBeforeUnmount, onMounted, ref, watch, type PropType } from "vue"
 import { PieChart } from "echarts/charts"
-import { TooltipComponent } from "echarts/components"
-import { use } from "echarts/core"
+import { GraphicComponent, TooltipComponent } from "echarts/components"
+import { init, use, type EChartsType } from "echarts/core"
 import { CanvasRenderer } from "echarts/renderers"
-import VChart from "vue-echarts"
 import SectorsCollation from "@/data/collations/SectorsCollation"
 import type { PortfolioSectorAllocationItem } from "@/data/Interfaces/PortfolioMetrics"
 import { formatMoney, formatPercent } from "@/utils/format"
 
-use([CanvasRenderer, PieChart, TooltipComponent])
+use([CanvasRenderer, PieChart, GraphicComponent, TooltipComponent])
 
 const colors = ["#2563eb", "#7c3aed", "#ea580c", "#059669", "#dc2626", "#ca8a04", "#0f766e", "#9333ea"]
 
@@ -56,65 +34,93 @@ const props = defineProps({
 	},
 })
 
+const chartElement = ref<HTMLDivElement | null>(null)
 const totalAmount = computed(() => props.items.reduce((sum, item) => sum + item.amountRub, 0))
 
-const chartOption = computed(() => ({
-	animation: false,
-	tooltip: {
-		trigger: "item",
-		backgroundColor: "rgba(15, 23, 42, 0.92)",
-		borderWidth: 0,
-		textStyle: {
-			color: "#f8fafc",
-		},
-		formatter: (params: { data: { amountRub: number; sharePct: number }; name: string }) => {
-			return [params.name, formatMoney(params.data.amountRub), formatPercent(params.data.sharePct)].join("<br/>")
-		},
-	},
-	graphic: [
-		{
-			type: "text",
-			left: "center",
-			top: "40%",
-			style: {
-				text: formatMoney(totalAmount.value),
-				textAlign: "center",
-				fill: "#0f172a",
-				fontSize: 15,
-				fontWeight: 600,
+let chart: EChartsType | undefined
+let resizeObserver: ResizeObserver | undefined
+
+const renderChart = () => {
+	if (!chartElement.value) {
+		return
+	}
+
+	if (!chart) {
+		chart = init(chartElement.value)
+	}
+
+	chart.setOption({
+		animation: false,
+		tooltip: {
+			trigger: "item",
+			backgroundColor: "rgba(15, 23, 42, 0.92)",
+			borderWidth: 0,
+			textStyle: { color: "#f8fafc" },
+			formatter: (params: { data: { amountRub: number; sharePct: number }; name: string }) => {
+				return [params.name, formatMoney(params.data.amountRub), formatPercent(params.data.sharePct)].join("<br/>")
 			},
 		},
-		{
-			type: "text",
-			left: "center",
-			top: "54%",
-			style: {
-				text: "Всего",
-				textAlign: "center",
-				fill: "rgba(15, 23, 42, 0.7)",
-				fontSize: 12,
+		graphic: [
+			{
+				type: "text",
+				left: "center",
+				top: "42%",
+				style: {
+					text: formatMoney(totalAmount.value),
+					textAlign: "center",
+					fill: "#0f172a",
+					fontSize: 15,
+					fontWeight: 600,
+				},
 			},
-		},
-	],
-	series: [
-		{
-			type: "pie",
-			radius: ["58%", "82%"],
-			avoidLabelOverlap: false,
-			label: { show: false },
-			labelLine: { show: false },
-			itemStyle: {
-				borderColor: "#ffffff",
-				borderWidth: 3,
+			{
+				type: "text",
+				left: "center",
+				top: "54%",
+				style: {
+					text: "Всего",
+					textAlign: "center",
+					fill: "rgba(15, 23, 42, 0.7)",
+					fontSize: 12,
+				},
 			},
-			data: props.items.map((item, index) => ({
-				value: item.amountRub,
-				name: SectorsCollation.getLabel(item.sector),
-				amountRub: item.amountRub,
-				sharePct: item.sharePct,
-				itemStyle: { color: colors[index % colors.length] },
-			})),
-		},
-	],
-}))
+		],
+		series: [
+			{
+				type: "pie",
+				radius: ["54%", "78%"],
+				center: ["50%", "50%"],
+				label: { show: false },
+				labelLine: { show: false },
+				itemStyle: {
+					borderColor: "#f8fafc",
+					borderWidth: 3,
+				},
+				data: props.items.map((item, index) => ({
+					value: item.amountRub,
+					name: SectorsCollation.getLabel(item.sector),
+					amountRub: item.amountRub,
+					sharePct: item.sharePct,
+					itemStyle: { color: colors[index % colors.length] },
+				})),
+			},
+		],
+	})
+}
+
+onMounted(() => {
+	renderChart()
+
+	if (chartElement.value) {
+		resizeObserver = new ResizeObserver(() => chart?.resize())
+		resizeObserver.observe(chartElement.value)
+	}
+})
+
+watch(() => props.items, renderChart, { deep: true })
+
+onBeforeUnmount(() => {
+	resizeObserver?.disconnect()
+	chart?.dispose()
+})
 </script>

--- a/UI/src/components/PortfolioStats.vue
+++ b/UI/src/components/PortfolioStats.vue
@@ -33,7 +33,7 @@
 							<td class="py-3 text-right">{{ formatMoney(metrics.totals.maturityValueRub) }}</td>
 						</tr>
 						<tr>
-							<td class="py-3 pr-4 font-medium">Сумма при погашении, % к покупке:</td>
+							<td class="py-3 pr-4 font-medium">Прибыль при погашении, % к покупке:</td>
 							<td class="py-3 text-right">{{ formatPercent(metrics.totals.maturityValuePct) }}</td>
 						</tr>
 					</tbody>
@@ -44,6 +44,39 @@
 					<div>Курсы ЦБ обновлены: {{ formatDateTime(metrics.actuality.ratesUpdatedAt) }}</div>
 					<div>Дата курсов ЦБ: {{ metrics.actuality.ratesDate }}</div>
 					<div>Портфель рассчитан: {{ formatDateTime(metrics.actuality.generatedAt) }}</div>
+				</div>
+			</div>
+
+			<div class="rounded-box border border-base-300 bg-base-100 p-4">
+				<div class="flex flex-wrap items-start justify-between gap-3">
+					<div>
+						<h3 class="text-base font-semibold text-base-content">Риск-профиль портфеля</h3>
+						<p class="text-sm text-base-content/70">Сводный риск по доминирующей доле текущей стоимости.</p>
+					</div>
+					<span class="badge badge-lg border-0 text-white" :class="riskBadgeClass(metrics.riskProfile.items[0]?.riskLevel ?? 0)">
+						{{ metrics.riskProfile.summary }}
+					</span>
+				</div>
+
+				<div v-if="metrics.riskProfile.items.length < 1" class="mt-4 rounded-box bg-base-200 px-4 py-6 text-sm text-base-content/70">
+					Нет данных по риск-профилю.
+				</div>
+
+				<div v-else class="mt-4 space-y-2">
+					<div
+						v-for="item in metrics.riskProfile.items"
+						:key="item.riskLevel"
+						class="flex items-start justify-between gap-3 rounded-box bg-base-200 px-3 py-2 text-sm"
+					>
+						<div class="flex items-center gap-2">
+							<span class="h-3 w-3 rounded-full" :class="riskDotClass(item.riskLevel)"></span>
+							<span>{{ item.label }}</span>
+						</div>
+						<div class="shrink-0 text-right">
+							<div class="font-medium text-base-content">{{ formatMoney(item.amountRub) }}</div>
+							<div class="text-xs text-base-content/70">{{ formatPercent(item.sharePct) }}</div>
+						</div>
+					</div>
 				</div>
 			</div>
 
@@ -59,11 +92,37 @@ import LoadingOverlay from "@/components/UI/LoadingOverlay.vue"
 import type { PortfolioMetricsResponse } from "@/data/Interfaces/PortfolioMetrics"
 import { formatDateTime, formatInteger, formatMoney, formatPercent } from "@/utils/format"
 
+const riskBadgeClass = (riskLevel: number) => {
+	switch (riskLevel) {
+		case 1:
+			return "bg-success"
+		case 2:
+			return "bg-warning text-base-100"
+		case 3:
+			return "bg-error"
+		default:
+			return "bg-neutral"
+	}
+}
+
+const riskDotClass = (riskLevel: number) => {
+	switch (riskLevel) {
+		case 1:
+			return "bg-success"
+		case 2:
+			return "bg-warning"
+		case 3:
+			return "bg-error"
+		default:
+			return "bg-neutral"
+	}
+}
+
 defineProps({
 	metrics: {
 		type: Object as PropType<PortfolioMetricsResponse | null>,
-		default: null
+		default: null,
 	},
-	loading: Boolean
+	loading: Boolean,
 })
 </script>

--- a/UI/src/data/Interfaces/PortfolioMetrics.ts
+++ b/UI/src/data/Interfaces/PortfolioMetrics.ts
@@ -24,6 +24,18 @@ export interface PortfolioSectorAllocationItem {
 	sharePct: number
 }
 
+export interface PortfolioRiskProfileItem {
+	riskLevel: number
+	label: string
+	amountRub: number
+	sharePct: number
+}
+
+export interface PortfolioRiskProfile {
+	summary: string
+	items: PortfolioRiskProfileItem[]
+}
+
 export interface PortfolioActuality {
 	bondsUpdatedAt?: string
 	ratesUpdatedAt: string
@@ -36,5 +48,6 @@ export interface PortfolioMetricsResponse {
 	totals: PortfolioTotals
 	couponSchedule: PortfolioCouponScheduleItem[]
 	sectorAllocation: PortfolioSectorAllocationItem[]
+	riskProfile: PortfolioRiskProfile
 	actuality: PortfolioActuality
 }

--- a/server/src/common/getPortfolioMetrics.test.ts
+++ b/server/src/common/getPortfolioMetrics.test.ts
@@ -25,6 +25,7 @@ describe("getPortfolioMetrics", () => {
 					nominal: 1000,
 					price: 90,
 					aciValue: 10,
+					riskLevel: 1,
 					leftToPay: 60,
 					leftCouponCount: 3,
 					coupons: [
@@ -41,6 +42,7 @@ describe("getPortfolioMetrics", () => {
 					nominal: 100,
 					price: 95,
 					aciValue: 5,
+					riskLevel: 3,
 					leftToPay: 15,
 					leftCouponCount: 2,
 					coupons: [
@@ -71,16 +73,23 @@ describe("getPortfolioMetrics", () => {
 			purchaseCostRub: 9820,
 			couponProfitRub: 1320,
 			maturityValueRub: 11320,
-			maturityValuePct: 115.27,
+			maturityValuePct: 15.27,
 		})
-		expect(result.couponSchedule[0]).toEqual({ month: "2026-04", label: "апр. 2026 г.", amountRub: 0 })
-		expect(result.couponSchedule[1]).toEqual({ month: "2026-05", label: "май 2026 г.", amountRub: 840 })
-		expect(result.couponSchedule[2]).toEqual({ month: "2026-06", label: "июнь 2026 г.", amountRub: 40 })
-		expect(result.couponSchedule[7]).toEqual({ month: "2026-11", label: "нояб. 2026 г.", amountRub: 400 })
+		expect(result.couponSchedule[0]).toEqual({ month: "2026-05", label: "май 2026 г.", amountRub: 840 })
+		expect(result.couponSchedule[1]).toEqual({ month: "2026-06", label: "июнь 2026 г.", amountRub: 40 })
+		expect(result.couponSchedule[6]).toEqual({ month: "2026-11", label: "нояб. 2026 г.", amountRub: 400 })
+		expect(result.couponSchedule[11]).toEqual({ month: "2027-04", label: "апр. 2027 г.", amountRub: 0 })
 		expect(result.sectorAllocation).toEqual([
 			{ sector: "it", amountRub: 7600, sharePct: 80.85 },
 			{ sector: "energy", amountRub: 1800, sharePct: 19.15 },
 		])
+		expect(result.riskProfile).toEqual({
+			summary: "Высокий",
+			items: [
+				{ riskLevel: 3, label: "Высокий", amountRub: 7600, sharePct: 80.85 },
+				{ riskLevel: 1, label: "Низкий", amountRub: 1800, sharePct: 19.15 },
+			],
+		})
 		expect(result.actuality).toEqual({
 			bondsUpdatedAt: "2026-04-20T03:00:00.000Z",
 			ratesUpdatedAt: "2026-04-20T04:00:00.000Z",
@@ -98,7 +107,7 @@ describe("getPortfolioMetrics", () => {
 
 		const result = await getPortfolioMetrics(
 			[{ uid: "bond-1", qty: 1 }],
-			[{ uid: "bond-1", figi: "figi-1", currency: "rub", sector: "other", nominal: 1000, price: 100, aciValue: 0 } as any],
+			[{ uid: "bond-1", figi: "figi-1", currency: "rub", sector: "other", riskLevel: 2, nominal: 1000, price: 100, aciValue: 0 } as any],
 			{ baseCurrency: "RUB", rateDate: "20.04.2026", updatedAt: "2026-04-20T04:00:00.000Z", rates: {} },
 			{ isBuilding: false, hasCachedData: true },
 			moment("2026-04-20T00:00:00.000Z"),
@@ -107,5 +116,36 @@ describe("getPortfolioMetrics", () => {
 		expect(getCouponSummaryMock).toHaveBeenCalledWith("figi-1", false, expect.anything())
 		expect(result.totals.totalCoupons).toBe(2)
 		expect(result.totals.couponProfitRub).toBe(30)
+		expect(result.riskProfile).toEqual({
+			summary: "Средний",
+			items: [{ riskLevel: 2, label: "Средний", amountRub: 1000, sharePct: 100 }],
+		})
+	})
+
+	test("keeps current month in coupon window on first day of month", async () => {
+		const result = await getPortfolioMetrics(
+			[{ uid: "bond-1", qty: 1 }],
+			[
+				{
+					uid: "bond-1",
+					figi: "figi-1",
+					currency: "rub",
+					sector: "other",
+					riskLevel: 1,
+					nominal: 1000,
+					price: 100,
+					aciValue: 0,
+					leftToPay: 20,
+					leftCouponCount: 1,
+					coupons: [{ couponDate: "2026-04-10T00:00:00.000Z", payout: 20 }],
+				} as any,
+			],
+			{ baseCurrency: "RUB", rateDate: "01.04.2026", updatedAt: "2026-04-01T04:00:00.000Z", rates: {} },
+			{ isBuilding: false, hasCachedData: true },
+			moment("2026-04-01T00:00:00.000Z"),
+		)
+
+		expect(result.couponSchedule[0]).toEqual({ month: "2026-04", label: "апр. 2026 г.", amountRub: 20 })
+		expect(result.couponSchedule[1]).toEqual({ month: "2026-05", label: "май 2026 г.", amountRub: 0 })
 	})
 })

--- a/server/src/common/getPortfolioMetrics.ts
+++ b/server/src/common/getPortfolioMetrics.ts
@@ -7,6 +7,8 @@ import {
 	type PortfolioCouponScheduleItem,
 	type PortfolioMetricsResponse,
 	type PortfolioPositionInput,
+	type PortfolioRiskProfile,
+	type PortfolioRiskProfileItem,
 	type PortfolioSectorAllocationItem,
 } from "./interfaces/PortfolioMetrics"
 import { roundTo } from "./utils/round"
@@ -21,6 +23,8 @@ export async function getPortfolioMetrics(
 	const bondByUid = new Map(bonds.map(bond => [bond.uid, bond]))
 	const scheduleByMonth = new Map<string, number>()
 	const sectorAmounts = new Map<string, number>()
+	const riskAmounts = new Map<number, number>()
+	const couponScheduleStart = getCouponScheduleStart(now)
 	let totalBonds = 0
 	let totalCoupons = 0
 	let purchaseCostRub = 0
@@ -58,13 +62,16 @@ export async function getPortfolioMetrics(
 		const sectorKey = typeof bond.sector === "string" && bond.sector ? bond.sector : "other"
 		sectorAmounts.set(sectorKey, roundTo((sectorAmounts.get(sectorKey) ?? 0) + sectorAmountRub) ?? 0)
 
+		const riskLevel = normalizeRiskLevel(bond.riskLevel)
+		riskAmounts.set(riskLevel, roundTo((riskAmounts.get(riskLevel) ?? 0) + sectorAmountRub) ?? 0)
+
 		for (const coupon of couponSummary?.coupons ?? []) {
 			const couponDate = moment(coupon.couponDate)
 			if (!couponDate.isValid()) {
 				continue
 			}
 
-			const monthDiff = couponDate.startOf("month").diff(now.clone().startOf("month"), "months")
+			const monthDiff = couponDate.startOf("month").diff(couponScheduleStart, "months")
 			if (monthDiff < 0 || monthDiff >= 12) {
 				continue
 			}
@@ -79,7 +86,7 @@ export async function getPortfolioMetrics(
 	const normalizedCouponProfitRub = roundTo(couponProfitRub) ?? 0
 	const normalizedMaturityValueRub = roundTo(maturityValueRub) ?? 0
 	const maturityValuePct = normalizedPurchaseCostRub > 0
-		? roundTo((normalizedMaturityValueRub / normalizedPurchaseCostRub) * 100) ?? 0
+		? roundTo(((normalizedMaturityValueRub - normalizedPurchaseCostRub) / normalizedPurchaseCostRub) * 100) ?? 0
 		: 0
 
 	return {
@@ -92,8 +99,9 @@ export async function getPortfolioMetrics(
 			maturityValueRub: normalizedMaturityValueRub,
 			maturityValuePct,
 		},
-		couponSchedule: buildCouponSchedule(scheduleByMonth, now),
+		couponSchedule: buildCouponSchedule(scheduleByMonth, couponScheduleStart),
 		sectorAllocation: buildSectorAllocation(sectorAmounts),
+		riskProfile: buildRiskProfile(riskAmounts),
 		actuality: {
 			bondsUpdatedAt: bondsStatus.lastBuildCompletedAt,
 			ratesUpdatedAt: rates.updatedAt,
@@ -116,7 +124,11 @@ async function resolveCouponSummary(bond: CombinedBondsResponse, now: moment.Mom
 	return getCouponSummary(String(bond.figi), Boolean(bond.floatingCouponFlag), now)
 }
 
-function buildCouponSchedule(scheduleByMonth: Map<string, number>, now: moment.Moment): PortfolioCouponScheduleItem[] {
+function getCouponScheduleStart(now: moment.Moment) {
+	return now.date() === 1 ? now.clone().startOf("month") : now.clone().add(1, "month").startOf("month")
+}
+
+function buildCouponSchedule(scheduleByMonth: Map<string, number>, startMonth: moment.Moment): PortfolioCouponScheduleItem[] {
 	const formatter = new Intl.DateTimeFormat("ru-RU", {
 		month: "short",
 		year: "numeric",
@@ -124,7 +136,7 @@ function buildCouponSchedule(scheduleByMonth: Map<string, number>, now: moment.M
 	})
 
 	return Array.from({ length: 12 }, (_, index) => {
-		const month = now.clone().startOf("month").add(index, "months")
+		const month = startMonth.clone().add(index, "months")
 		const monthKey = month.format("YYYY-MM")
 		return {
 			month: monthKey,
@@ -144,4 +156,39 @@ function buildSectorAllocation(sectorAmounts: Map<string, number>): PortfolioSec
 			sharePct: total > 0 ? roundTo((amountRub / total) * 100) ?? 0 : 0,
 		}))
 		.sort((a, b) => b.amountRub - a.amountRub)
+}
+
+function buildRiskProfile(riskAmounts: Map<number, number>): PortfolioRiskProfile {
+	const total = Array.from(riskAmounts.values()).reduce((sum, amount) => sum + amount, 0)
+	const items: PortfolioRiskProfileItem[] = Array.from(riskAmounts.entries())
+		.map(([riskLevel, amountRub]) => ({
+			riskLevel,
+			label: getRiskLabel(riskLevel),
+			amountRub: roundTo(amountRub) ?? 0,
+			sharePct: total > 0 ? roundTo((amountRub / total) * 100) ?? 0 : 0,
+		}))
+		.sort((a, b) => b.amountRub - a.amountRub)
+
+	return {
+		summary: items[0]?.label ?? getRiskLabel(0),
+		items,
+	}
+}
+
+function normalizeRiskLevel(value: unknown) {
+	const riskLevel = Number(value ?? 0)
+	return riskLevel >= 1 && riskLevel <= 3 ? riskLevel : 0
+}
+
+function getRiskLabel(riskLevel: number) {
+	switch (riskLevel) {
+		case 1:
+			return "Низкий"
+		case 2:
+			return "Средний"
+		case 3:
+			return "Высокий"
+		default:
+			return "Не определен"
+	}
 }

--- a/server/src/common/interfaces/PortfolioMetrics.ts
+++ b/server/src/common/interfaces/PortfolioMetrics.ts
@@ -24,6 +24,18 @@ export interface PortfolioSectorAllocationItem {
 	sharePct: number
 }
 
+export interface PortfolioRiskProfileItem {
+	riskLevel: number
+	label: string
+	amountRub: number
+	sharePct: number
+}
+
+export interface PortfolioRiskProfile {
+	summary: string
+	items: PortfolioRiskProfileItem[]
+}
+
 export interface PortfolioActuality {
 	bondsUpdatedAt?: string
 	ratesUpdatedAt: string
@@ -36,5 +48,6 @@ export interface PortfolioMetricsResponse {
 	totals: PortfolioTotals
 	couponSchedule: PortfolioCouponScheduleItem[]
 	sectorAllocation: PortfolioSectorAllocationItem[]
+	riskProfile: PortfolioRiskProfile
 	actuality: PortfolioActuality
 }


### PR DESCRIPTION
## Summary
- перевести графики купонов и структуры по секторам на ECharts, добавить tooltip и корректную поддержку светлой/темной темы
- обновить расчет метрик портфеля: показывать прибыль при погашении, сдвинуть окно купонов по правилу 1-го числа и добавить риск-профиль по доминирующей доле
- обновить UI блока статистики и серверные тесты под новую бизнес-логику

## Testing
- bun run build (UI)
- bun run test (server)
- bun run build (server)