### PR TITLE
feat(ui): добавить фильтр по месяцам купонов

### DIFF
--- a/UI/src/components/BondsFilter.vue
+++ b/UI/src/components/BondsFilter.vue
@@ -317,10 +317,10 @@
 
 <script lang="ts">
 import { BondOptionsChecks, BondOptionsRadios, BondOptionsSelect } from '@/components/UI'
-import { type FilterValues, type FilterOptions } from '@/data/Types/FilterOptions'
+import { type CouponMonthsMatchMode, type FilterValues, type FilterOptions } from '@/data/Types/FilterOptions'
 import type { PropType } from 'vue'
 
-const couponMonthsMatchModeOptions = [
+const couponMonthsMatchModeOptions: { value: CouponMonthsMatchMode; label: string }[] = [
   { value: 'any', label: 'Хотя бы один' },
   { value: 'all', label: 'Все выбранные' }
 ]

--- a/UI/src/components/BondsFilter.vue
+++ b/UI/src/components/BondsFilter.vue
@@ -152,6 +152,31 @@
         :options="filterOptions.countryOfRisk"
         label="Страна"
       />
+      <bond-options-checks
+        v-model="value.couponMonths"
+        :options="filterOptions.couponMonths"
+        label="Месяцы купонов"
+        group-name="couponMonths"
+        size="btn-sm"
+      />
+    </section>
+
+    <section class="grid grid-cols-1 gap-3 xl:grid-cols-2 2xl:grid-cols-3">
+      <div class="space-y-1">
+        <label class="label-text block text-sm font-medium text-base-content">Совпадение месяцев</label>
+        <div class="flex flex-wrap gap-1">
+          <button
+            v-for="option in couponMonthsMatchModeOptions"
+            :key="option.value"
+            type="button"
+            class="btn btn-sm"
+            :class="value.couponMonthsMatchMode === option.value ? 'btn-primary' : 'btn-outline'"
+            @click="value.couponMonthsMatchMode = option.value"
+          >
+            {{ option.label }}
+          </button>
+        </div>
+      </div>
     </section>
 
     <section class="grid grid-cols-1 gap-3 xl:grid-cols-2 2xl:grid-cols-3">
@@ -295,6 +320,11 @@ import { BondOptionsChecks, BondOptionsRadios, BondOptionsSelect } from '@/compo
 import { type FilterValues, type FilterOptions } from '@/data/Types/FilterOptions'
 import type { PropType } from 'vue'
 
+const couponMonthsMatchModeOptions = [
+  { value: 'any', label: 'Хотя бы один' },
+  { value: 'all', label: 'Все выбранные' }
+]
+
 export default {
   name: 'BondFilter',
   props: {
@@ -310,7 +340,8 @@ export default {
 
   data() {
     return {
-      value: this.modelValue
+      value: this.modelValue,
+      couponMonthsMatchModeOptions
     }
   },
 

--- a/UI/src/components/BondsFilter.vue
+++ b/UI/src/components/BondsFilter.vue
@@ -152,7 +152,7 @@
         :options="filterOptions.countryOfRisk"
         label="Страна"
       />
-      <div class="space-y-3 rounded-box border border-base-300 bg-base-100 p-2.5 xl:col-span-2 2xl:col-span-1">
+      <div class="space-y-3 rounded-box border border-base-300 bg-base-100 p-2.5 xl:col-span-2 2xl:col-span-3">
         <div class="space-y-1">
           <div class="flex items-center gap-2">
             <label class="label-text block text-sm font-medium text-base-content">Месяцы купонов</label>

--- a/UI/src/components/BondsFilter.vue
+++ b/UI/src/components/BondsFilter.vue
@@ -152,29 +152,44 @@
         :options="filterOptions.countryOfRisk"
         label="Страна"
       />
-      <bond-options-checks
-        v-model="value.couponMonths"
-        :options="filterOptions.couponMonths"
-        label="Месяцы купонов"
-        group-name="couponMonths"
-        size="btn-sm"
-      />
-    </section>
-
-    <section class="grid grid-cols-1 gap-3 xl:grid-cols-2 2xl:grid-cols-3">
-      <div class="space-y-1">
-        <label class="label-text block text-sm font-medium text-base-content">Совпадение месяцев</label>
-        <div class="flex flex-wrap gap-1">
-          <button
-            v-for="option in couponMonthsMatchModeOptions"
-            :key="option.value"
-            type="button"
-            class="btn btn-sm"
-            :class="value.couponMonthsMatchMode === option.value ? 'btn-primary' : 'btn-outline'"
-            @click="value.couponMonthsMatchMode = option.value"
-          >
-            {{ option.label }}
-          </button>
+      <div class="space-y-3 rounded-box border border-base-300 bg-base-100 p-2.5 xl:col-span-2 2xl:col-span-1">
+        <div class="space-y-1">
+          <div class="flex items-center gap-2">
+            <label class="label-text block text-sm font-medium text-base-content">Месяцы купонов</label>
+            <div
+              class="tooltip tooltip-right"
+              data-tip="Хотя бы один: облигация подойдет, если выплата есть хотя бы в одном выбранном месяце. Все выбранные: облигация подойдет только если выплаты есть во всех выбранных месяцах."
+            >
+              <button
+                type="button"
+                class="inline-flex h-5 w-5 items-center justify-center rounded-full border border-base-300 text-xs font-semibold text-base-content/70 transition hover:border-base-content/30 hover:text-base-content"
+                aria-label="Пояснение по режимам совпадения месяцев"
+              >
+                ?
+              </button>
+            </div>
+          </div>
+          <bond-options-checks
+            v-model="value.couponMonths"
+            :options="filterOptions.couponMonths"
+            group-name="couponMonths"
+            size="btn-sm"
+          />
+        </div>
+        <div class="space-y-1">
+          <label class="label-text block text-sm font-medium text-base-content">Тип совпадения</label>
+          <div class="flex flex-wrap gap-1">
+            <button
+              v-for="option in couponMonthsMatchModeOptions"
+              :key="option.value"
+              type="button"
+              class="btn btn-sm"
+              :class="value.couponMonthsMatchMode === option.value ? 'btn-primary' : 'btn-outline'"
+              @click="value.couponMonthsMatchMode = option.value"
+            >
+              {{ option.label }}
+            </button>
+          </div>
         </div>
       </div>
     </section>

--- a/UI/src/components/PortfolioStats.vue
+++ b/UI/src/components/PortfolioStats.vue
@@ -80,17 +80,20 @@
 				</div>
 			</div>
 
-			<portfolio-coupon-chart :items="metrics.couponSchedule" />
-			<portfolio-sector-chart :items="metrics.sectorAllocation" />
+			<PortfolioCouponChart :items="metrics.couponSchedule" />
+			<PortfolioSectorChart :items="metrics.sectorAllocation" />
 		</template>
 	</div>
 </template>
 
 <script lang="ts" setup>
-import type { PropType } from "vue"
+import { defineAsyncComponent, type PropType } from "vue"
 import LoadingOverlay from "@/components/UI/LoadingOverlay.vue"
 import type { PortfolioMetricsResponse } from "@/data/Interfaces/PortfolioMetrics"
 import { formatDateTime, formatInteger, formatMoney, formatPercent } from "@/utils/format"
+
+const PortfolioCouponChart = defineAsyncComponent(() => import("@/components/PortfolioCouponChart.vue"))
+const PortfolioSectorChart = defineAsyncComponent(() => import("@/components/PortfolioSectorChart.vue"))
 
 const riskBadgeClass = (riskLevel: number) => {
 	switch (riskLevel) {

--- a/UI/src/data/Types/FilterOptions.ts
+++ b/UI/src/data/Types/FilterOptions.ts
@@ -10,6 +10,7 @@ import LiquidityCollations from '@/data/collations/LiquidityCollations'
 export type FromTo = { from: number; to: number }
 
 export type CouponMonthsMatchMode = 'any' | 'all'
+export type NumericFilterOption = { value: number; label: string }
 
 export interface FilterOptions {
   search: string
@@ -62,7 +63,7 @@ export interface FilterValues {
   classCode: CollationItem[]
   currency: CollationItem[]
   couponQuantityPerYear: CollationItem[]
-  couponMonths: CollationItem[]
+  couponMonths: NumericFilterOption[]
   countryOfRisk: CollationItem[]
   sector: CollationItem[]
   issueKind: CollationItem[]

--- a/UI/src/data/Types/FilterOptions.ts
+++ b/UI/src/data/Types/FilterOptions.ts
@@ -9,6 +9,8 @@ import LiquidityCollations from '@/data/collations/LiquidityCollations'
 
 export type FromTo = { from: number; to: number }
 
+export type CouponMonthsMatchMode = 'any' | 'all'
+
 export interface FilterOptions {
   search: string
   nominal: FromTo
@@ -37,6 +39,8 @@ export interface FilterOptions {
   classCode: number[]
   currency: string[]
   couponQuantityPerYear: number[]
+  couponMonths: number[]
+  couponMonthsMatchMode: CouponMonthsMatchMode
   countryOfRisk: string[]
   sector: string[]
   issueKind: string[]
@@ -58,6 +62,7 @@ export interface FilterValues {
   classCode: CollationItem[]
   currency: CollationItem[]
   couponQuantityPerYear: CollationItem[]
+  couponMonths: CollationItem[]
   countryOfRisk: CollationItem[]
   sector: CollationItem[]
   issueKind: CollationItem[]
@@ -75,6 +80,20 @@ export const defaultFilterValues: FilterValues = {
   classCode: [],
   currency: CurrencyCollation.asArray(),
   couponQuantityPerYear: [],
+  couponMonths: [
+    { value: 0, label: 'янв' },
+    { value: 1, label: 'фев' },
+    { value: 2, label: 'мар' },
+    { value: 3, label: 'апр' },
+    { value: 4, label: 'май' },
+    { value: 5, label: 'июн' },
+    { value: 6, label: 'июл' },
+    { value: 7, label: 'авг' },
+    { value: 8, label: 'сен' },
+    { value: 9, label: 'окт' },
+    { value: 10, label: 'ноя' },
+    { value: 11, label: 'дек' }
+  ],
   countryOfRisk: CountryCollation.asArray(),
   sector: SectorsCollation.asArray(),
   issueKind: IssueKindCollations.asArray()
@@ -108,6 +127,8 @@ export const DefaultFilterSelections: FilterOptions = {
   classCode: [],
   currency: [],
   couponQuantityPerYear: [],
+  couponMonths: [],
+  couponMonthsMatchMode: 'any',
   countryOfRisk: [],
   sector: [],
   issueKind: [],

--- a/UI/src/views/HomeView.vue
+++ b/UI/src/views/HomeView.vue
@@ -67,6 +67,7 @@
 
 <script lang="ts">
 import BondsRepository from "@/data/BondsRepository"
+import moment from "moment"
 import { computed, onBeforeUnmount, ref } from "vue"
 import { useStorage } from "@vueuse/core"
 
@@ -78,8 +79,41 @@ import { DefaultFilterSelections, defaultFilterValues } from "@/data/Types/Filte
 import type { CombinedBondsResponse } from "@/data/Interfaces/CombinedBondsResponse"
 import type { BondsDataStatus } from "@/data/Interfaces/BondsDataStatus"
 import type { sortState } from "@/data/Types/SortState"
+import type { CombinedCoupon } from "@/data/Interfaces/CombinedCoupon"
 
 const STATUS_POLL_INTERVAL_MS = 10_000
+
+const createFilterSelections = (storedFilters: Partial<FilterOptions> | undefined): FilterOptions => ({
+	...DefaultFilterSelections,
+	...storedFilters,
+	nominal: {
+		...DefaultFilterSelections.nominal,
+		...storedFilters?.nominal,
+	},
+	price: {
+		...DefaultFilterSelections.price,
+		...storedFilters?.price,
+	},
+	bondYield: {
+		...DefaultFilterSelections.bondYield,
+		...storedFilters?.bondYield,
+	},
+	duration: {
+		...DefaultFilterSelections.duration,
+		...storedFilters?.duration,
+	},
+})
+
+const getKnownCouponMonths = (coupons?: CombinedCoupon[]) => {
+	if (!Array.isArray(coupons) || coupons.length < 1) {
+		return []
+	}
+
+	return [...new Set(coupons.flatMap((coupon) => {
+		const couponDate = moment(coupon.couponDate)
+		return couponDate.isValid() ? [couponDate.month()] : []
+	}))]
+}
 
 export default {
 	name: "HomeView",
@@ -90,12 +124,13 @@ export default {
 			"filterSelections",
 			DefaultFilterSelections
 		)
+		filterSelectionsStore.value = createFilterSelections(filterSelectionsStore.value)
 		const sortState = useStorage<sortState>("sort-state", {
 			prop: "name",
 			order: "ascending"
 		})
 
-		const filterSelections = ref<FilterOptions>(filterSelectionsStore.value)
+		const filterSelections = ref<FilterOptions>(createFilterSelections(filterSelectionsStore.value))
 
 		const filterOptions = ref(defaultFilterValues)
 
@@ -212,7 +247,11 @@ export default {
 		}
 		const updateTable = () => {
 			isFetching.value = true
-			const appliedFilters = Object.entries(filterSelections.value).filter(([, value]) => {
+			const appliedFilters = Object.entries(filterSelections.value).filter(([key, value]) => {
+				if (key === "couponMonthsMatchMode") {
+					return false
+				}
+
 				if (value === undefined) {
 					return false
 				} else if (Array.isArray(value)) {
@@ -228,6 +267,24 @@ export default {
 
 			const filtered = response.value.filter((bond) => {
 				for (const [key, value] of appliedFilters) {
+					if (key === "couponMonths") {
+						const knownCouponMonths = getKnownCouponMonths(bond.coupons)
+						if (knownCouponMonths.length < 1) {
+							return false
+						}
+
+						const selectedMonths = value as number[]
+						const hasMatch = filterSelections.value.couponMonthsMatchMode === "all"
+							? selectedMonths.every((month) => knownCouponMonths.includes(month))
+							: selectedMonths.some((month) => knownCouponMonths.includes(month))
+
+						if (!hasMatch) {
+							return false
+						}
+
+						continue
+					}
+
 					if (key == "search") {
 						const filterValue = value.toString().toLowerCase()
 						const bondName = bond.name.toString().toLowerCase()

--- a/UI/tsconfig.app.json
+++ b/UI/tsconfig.app.json
@@ -13,7 +13,6 @@
   ],
   "compilerOptions": {
     "composite": true,
-    "baseUrl": ".",
     "allowJs": true,
     "paths": {
       "@/*": [


### PR DESCRIPTION
## Summary
- добавить выбор месяцев купонов в фильтр интерфейса и сохранять это состояние
- фильтровать облигации по известным месяцам купонов и собрать элементы управления в один общий блок
- оставить изменения совместимыми с текущей настройкой ESLint 10 и с зелёными локальными проверками UI