### PR TITLE
feat(ui): добавить сохранение портфелей в браузере

### DIFF
--- a/UI/package.json
+++ b/UI/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "run-p type-check build-only",
     "preview": "vite preview",
-    "test": "bun test src/utils/portfolio.test.ts",
+    "test": "bun test",
     "build-only": "vite build",
     "type-check": "vue-tsc --noEmit -p tsconfig.app.json --composite false",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix",

--- a/UI/src/components.d.ts
+++ b/UI/src/components.d.ts
@@ -25,6 +25,7 @@ declare module 'vue' {
     PortfolioPriceCell: typeof import('./components/PortfolioPriceCell.vue')['default']
     PortfolioSectorChart: typeof import('./components/PortfolioSectorChart.vue')['default']
     PortfolioStats: typeof import('./components/PortfolioStats.vue')['default']
+    PortfolioSwitcher: typeof import('./components/PortfolioSwitcher.vue')['default']
     PortfolioTable: typeof import('./components/PortfolioTable.vue')['default']
     RiskStars: typeof import('./components/UI/RiskStars.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']

--- a/UI/src/components/PortfolioStats.vue
+++ b/UI/src/components/PortfolioStats.vue
@@ -80,17 +80,20 @@
 				</div>
 			</div>
 
-			<portfolio-coupon-chart :items="metrics.couponSchedule" />
-			<portfolio-sector-chart :items="metrics.sectorAllocation" />
+			<PortfolioCouponChart :items="metrics.couponSchedule" />
+			<PortfolioSectorChart :items="metrics.sectorAllocation" />
 		</template>
 	</div>
 </template>
 
 <script lang="ts" setup>
-import type { PropType } from "vue"
+import { defineAsyncComponent, type PropType } from "vue"
 import LoadingOverlay from "@/components/UI/LoadingOverlay.vue"
 import type { PortfolioMetricsResponse } from "@/data/Interfaces/PortfolioMetrics"
 import { formatDateTime, formatInteger, formatMoney, formatPercent } from "@/utils/format"
+
+const PortfolioCouponChart = defineAsyncComponent(() => import("@/components/PortfolioCouponChart.vue"))
+const PortfolioSectorChart = defineAsyncComponent(() => import("@/components/PortfolioSectorChart.vue"))
 
 const riskBadgeClass = (riskLevel: number) => {
 	switch (riskLevel) {

--- a/UI/src/components/PortfolioSwitcher.vue
+++ b/UI/src/components/PortfolioSwitcher.vue
@@ -1,0 +1,78 @@
+<template>
+	<div class="flex flex-wrap items-center justify-end gap-2">
+		<label class="flex items-center gap-2 text-sm text-base-content/70">
+			<span class="hidden xl:inline">Портфель</span>
+			<select v-model="activePortfolioId" class="select select-bordered select-sm max-w-52">
+				<option v-for="portfolio in store.portfolios" :key="portfolio.id" :value="portfolio.id">
+					{{ portfolio.name }}
+				</option>
+			</select>
+		</label>
+
+		<button type="button" class="btn btn-ghost btn-sm" title="Новый портфель" @click="createPortfolio">
+			Новый
+		</button>
+		<button type="button" class="btn btn-ghost btn-sm" title="Дублировать портфель" @click="duplicatePortfolio">
+			Копия
+		</button>
+		<button type="button" class="btn btn-ghost btn-sm" title="Переименовать портфель" @click="renamePortfolio">
+			Имя
+		</button>
+		<button
+			type="button"
+			class="btn btn-ghost btn-sm text-error"
+			:disabled="!store.canDeletePortfolios"
+			title="Удалить портфель"
+			@click="deletePortfolio"
+		>
+			Удалить
+		</button>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue"
+import { portfolioStore } from "@/data/portfolioStore"
+
+const store = portfolioStore()
+
+const activePortfolioId = computed({
+	get: () => store.activePortfolioId,
+	set: (id: string) => store.switchPortfolio(id)
+})
+
+const createPortfolio = () => {
+	const name = window.prompt("Название нового портфеля", `Портфель ${store.portfolios.length + 1}`)
+	if (name === null) {
+		return
+	}
+
+	store.createPortfolio(name)
+}
+
+const renamePortfolio = () => {
+	const name = window.prompt("Новое название портфеля", store.activePortfolio.name)
+	if (name === null) {
+		return
+	}
+
+	store.renamePortfolio(store.activePortfolioId, name)
+}
+
+const duplicatePortfolio = () => {
+	store.duplicatePortfolio(store.activePortfolioId)
+}
+
+const deletePortfolio = () => {
+	if (!store.canDeletePortfolios) {
+		return
+	}
+
+	const confirmed = window.confirm(`Удалить портфель «${store.activePortfolio.name}»?`)
+	if (!confirmed) {
+		return
+	}
+
+	store.deletePortfolio(store.activePortfolioId)
+}
+</script>

--- a/UI/src/components/UI/BaseHeader.vue
+++ b/UI/src/components/UI/BaseHeader.vue
@@ -1,6 +1,6 @@
 <template>
 	<header class="border-b border-base-300 bg-base-100/90 backdrop-blur">
-		<nav class="navbar min-h-[var(--header-height)] gap-3 px-4">
+		<nav class="navbar min-h-[var(--header-height)] flex-wrap gap-3 px-4 py-2">
 			<RouterLink
 				to="/"
 				class="text-lg font-semibold text-base-content transition hover:text-primary"
@@ -18,6 +18,7 @@
 					{{ store.bondsQty > 99 ? "99+" : store.bondsQty }}
 				</span>
 			</RouterLink>
+			<portfolio-switcher />
 			<button
 				type="button"
 				class="btn btn-ghost btn-square btn-sm"

--- a/UI/src/data/portfolioStore.test.ts
+++ b/UI/src/data/portfolioStore.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import { createPinia, setActivePinia } from "pinia"
+import {
+	createDefaultPortfolioState,
+	migratePortfolioStorage,
+	normalizePortfolioBonds,
+	portfolioStore,
+	usePortfolioStore,
+	type PortfolioStorageState
+} from "./portfolioStore"
+
+type StorageMock = {
+	clear(): void
+	getItem(key: string): string | null
+	removeItem(key: string): void
+	setItem(key: string, value: string): void
+}
+
+const createLocalStorageMock = (): StorageMock => {
+	const storage = new Map<string, string>()
+
+	return {
+		clear() {
+			storage.clear()
+		},
+		getItem(key) {
+			return storage.has(key) ? storage.get(key) ?? null : null
+		},
+		removeItem(key) {
+			storage.delete(key)
+		},
+		setItem(key, value) {
+			storage.set(key, String(value))
+		}
+	}
+}
+
+describe("portfolio store", () => {
+	beforeEach(() => {
+		;(globalThis as typeof globalThis & {
+			window: { localStorage: StorageMock }
+		}).window = {
+			localStorage: createLocalStorageMock()
+		}
+
+		window.localStorage.clear()
+		setActivePinia(createPinia())
+	})
+
+	test("migrates legacy bonds storage into a default saved portfolio", () => {
+		const migration = migratePortfolioStorage(null, {
+			bondA: { uid: "bondA", qty: 2 },
+			bondB: { uid: "bondB", qty: 0 }
+		})
+
+		expect(migration.consumeLegacy).toBe(true)
+		expect(migration.state.activePortfolioId).toBeTruthy()
+		expect(Object.keys(migration.state.portfolios)).toHaveLength(1)
+
+		const activePortfolio = migration.state.portfolios[migration.state.activePortfolioId]
+		expect(activePortfolio.name).toBe("Мой портфель")
+		expect(activePortfolio.bonds).toEqual({
+			bondA: { uid: "bondA", qty: 2 }
+		})
+	})
+
+	test("keeps new storage format and normalizes invalid entries", () => {
+		const rawState = {
+			activePortfolioId: "second",
+			portfolios: {
+				first: {
+					id: "first",
+					name: "  Первый  ",
+					bonds: {
+						bondA: { qty: 3 }
+					}
+				},
+				second: {
+					id: "second",
+					name: "",
+					bonds: {
+						bondB: { uid: "bondB", qty: 1 },
+						bondC: { uid: "bondC", qty: -1 }
+					}
+				}
+			}
+		}
+
+		const migration = migratePortfolioStorage(rawState, {
+			legacy: { uid: "legacy", qty: 10 }
+		})
+
+		expect(migration.consumeLegacy).toBe(false)
+		expect(migration.state.activePortfolioId).toBe("second")
+		expect(migration.state.portfolios.first.name).toBe("Первый")
+		expect(migration.state.portfolios.first.bonds).toEqual({
+			bondA: { uid: "bondA", qty: 3 }
+		})
+		expect(migration.state.portfolios.second.bonds).toEqual({
+			bondB: { uid: "bondB", qty: 1 }
+		})
+	})
+
+	test("creates a default portfolio when storage is empty", () => {
+		const state = createDefaultPortfolioState()
+
+		expect(Object.keys(state.portfolios)).toHaveLength(1)
+		expect(state.portfolios[state.activePortfolioId].name).toBe("Мой портфель")
+		expect(state.portfolios[state.activePortfolioId].bonds).toEqual({})
+	})
+
+	test("keeps active portfolio positions isolated when switching", () => {
+		const store = usePortfolioStore()
+		store.storage = createDefaultPortfolioState() as PortfolioStorageState
+
+		const firstId = store.activePortfolioId
+		store.increaseQty("bondA")
+		store.createPortfolio("Второй")
+		const secondId = store.activePortfolioId
+
+		store.increaseQty("bondB")
+		expect(store.positions).toEqual([{ uid: "bondB", qty: 1 }])
+
+		store.switchPortfolio(firstId)
+		expect(store.positions).toEqual([{ uid: "bondA", qty: 1 }])
+
+		store.switchPortfolio(secondId)
+		expect(store.positions).toEqual([{ uid: "bondB", qty: 1 }])
+	})
+
+	test("duplicates and deletes portfolios safely", () => {
+		const store = usePortfolioStore()
+		store.storage = createDefaultPortfolioState() as PortfolioStorageState
+		store.increaseQty("bondA")
+
+		const sourceId = store.activePortfolioId
+		store.duplicatePortfolio(sourceId)
+
+		expect(store.portfolios).toHaveLength(2)
+		expect(store.positions).toEqual([{ uid: "bondA", qty: 1 }])
+
+		const duplicateId = store.activePortfolioId
+		expect(duplicateId).not.toBe(sourceId)
+
+		store.deletePortfolio(duplicateId)
+		expect(store.portfolios).toHaveLength(1)
+		expect(store.activePortfolioId).toBe(sourceId)
+		expect(store.deletePortfolio(sourceId)).toBe(false)
+	})
+
+	test("normalizes legacy bond maps and drops zero quantities", () => {
+		expect(normalizePortfolioBonds({
+			bondA: { uid: "bondA", qty: 2 },
+			bondB: { uid: "bondB", qty: 0 },
+			bondC: { qty: 4 }
+		})).toEqual({
+			bondA: { uid: "bondA", qty: 2 },
+			bondC: { uid: "bondC", qty: 4 }
+		})
+	})
+
+	test("consumes legacy localStorage on store bootstrap", () => {
+		window.localStorage.setItem("bonds", JSON.stringify({
+			bondA: { uid: "bondA", qty: 2 }
+		}))
+
+		const store = portfolioStore()
+
+		expect(store.positions).toEqual([{ uid: "bondA", qty: 2 }])
+		expect(window.localStorage.getItem("bonds")).toBeNull()
+	})
+})

--- a/UI/src/data/portfolioStore.ts
+++ b/UI/src/data/portfolioStore.ts
@@ -10,26 +10,52 @@ export interface PortfolioPositionStored {
 
 type LegacyPortfolioPosition = CombinedBondsResponse | PortfolioPositionStored
 
-export interface PortfolioStore {
+export interface PortfolioBondsStore {
 	[key: string]: LegacyPortfolioPosition
 }
 
+export interface SavedPortfolio {
+	id: string
+	name: string
+	bonds: Record<string, PortfolioPositionStored>
+	createdAt: string
+	updatedAt: string
+}
+
+export interface PortfolioStorageState {
+	activePortfolioId: string
+	portfolios: Record<string, SavedPortfolio>
+}
+
+const PORTFOLIO_STORAGE_KEY = "portfolio-storage"
+const LEGACY_BONDS_STORAGE_KEY = "bonds"
+const DEFAULT_PORTFOLIO_NAME = "Мой портфель"
+
 export const usePortfolioStore = defineStore("portfolio", {
 	state: () => ({
-		bonds: useStorage("bonds", {} as PortfolioStore)
+		storage: useStorage(PORTFOLIO_STORAGE_KEY, createDefaultPortfolioState())
 	}),
 	getters: {
+		activePortfolio(): SavedPortfolio {
+			return getActivePortfolio(this.storage)
+		},
+		activePortfolioId(): string {
+			return getActivePortfolio(this.storage).id
+		},
+		portfolios(): SavedPortfolio[] {
+			return Object.values(this.storage.portfolios).sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+		},
 		bondsQty(): number {
 			let qty = 0
-			for (const bondId in this.bonds) {
-				qty += normalizePortfolioPosition(this.bonds[bondId], bondId).qty
+			for (const bondId in this.activePortfolio.bonds) {
+				qty += this.activePortfolio.bonds[bondId].qty
 			}
 			return qty
 		},
 		positions(): PortfolioPositionInput[] {
 			const bonds: PortfolioPositionInput[] = []
-			for (const bondId in this.bonds) {
-				const position = normalizePortfolioPosition(this.bonds[bondId], bondId)
+			for (const bondId in this.activePortfolio.bonds) {
+				const position = normalizePortfolioPosition(this.activePortfolio.bonds[bondId], bondId)
 				if (position.qty > 0) {
 					bonds.push(position)
 				}
@@ -37,74 +63,345 @@ export const usePortfolioStore = defineStore("portfolio", {
 			return bonds
 		},
 		isEmpty(): boolean {
-			return Object.keys(this.bonds).length < 1
+			return Object.keys(this.activePortfolio.bonds).length < 1
+		},
+		canDeletePortfolios(): boolean {
+			return Object.keys(this.storage.portfolios).length > 1
 		}
 	},
 	actions: {
 		ensureMigrated() {
-			const normalized: Record<string, PortfolioPositionStored> = {}
-			for (const bondId in this.bonds) {
-				const position = normalizePortfolioPosition(this.bonds[bondId], bondId)
-				if (position.qty > 0) {
-					normalized[position.uid] = position
-				}
+			const persistedStorage = readStorageValue(PORTFOLIO_STORAGE_KEY)
+			const legacyBonds = readLegacyPortfolioStore()
+			const result = migratePortfolioStorage(persistedStorage ?? (legacyBonds ? null : this.storage), legacyBonds)
+			this.storage = result.state
+
+			if (result.consumeLegacy && canUseLocalStorage()) {
+				window.localStorage.removeItem(LEGACY_BONDS_STORAGE_KEY)
+			}
+		},
+		createPortfolio(name?: string) {
+			const id = createPortfolioId()
+			const portfolio = createEmptyPortfolio(id, getPortfolioName(name, this.portfolios.length + 1))
+			this.storage.portfolios[id] = portfolio
+			this.storage.activePortfolioId = id
+		},
+		switchPortfolio(id: string) {
+			if (this.storage.portfolios[id]) {
+				this.storage.activePortfolioId = id
+			}
+		},
+		renamePortfolio(id: string, name: string) {
+			const portfolio = this.storage.portfolios[id]
+			if (!portfolio) {
+				return
 			}
 
-			this.bonds = normalized
+			portfolio.name = getPortfolioName(name, 0, portfolio.name)
+			portfolio.updatedAt = createTimestamp()
+		},
+		duplicatePortfolio(id: string) {
+			const portfolio = this.storage.portfolios[id]
+			if (!portfolio) {
+				return
+			}
+
+			const nextId = createPortfolioId()
+			const timestamp = createTimestamp()
+			this.storage.portfolios[nextId] = {
+				id: nextId,
+				name: `${portfolio.name} (копия)`,
+				bonds: clonePortfolioBonds(portfolio.bonds),
+				createdAt: timestamp,
+				updatedAt: timestamp
+			}
+			this.storage.activePortfolioId = nextId
+		},
+		deletePortfolio(id: string) {
+			if (!this.storage.portfolios[id] || Object.keys(this.storage.portfolios).length < 2) {
+				return false
+			}
+
+			delete this.storage.portfolios[id]
+			if (this.storage.activePortfolioId === id) {
+				this.storage.activePortfolioId = Object.keys(this.storage.portfolios)[0]
+			}
+
+			return true
 		},
 		increaseQty(bond: Pick<CombinedBondsResponse, "uid"> | string) {
 			const uid = typeof bond === "string" ? bond : bond.uid
-			if (this.bonds[uid]) {
-				this.bonds[uid] = {
+			const activePortfolio = getActivePortfolio(this.storage)
+			if (activePortfolio.bonds[uid]) {
+				activePortfolio.bonds[uid] = {
 					uid,
-					qty: normalizePortfolioPosition(this.bonds[uid], uid).qty + 1
+					qty: normalizePortfolioPosition(activePortfolio.bonds[uid], uid).qty + 1
 				}
 			} else {
-				this.bonds[uid] = { uid, qty: 1 }
+				activePortfolio.bonds[uid] = { uid, qty: 1 }
 			}
+
+			activePortfolio.updatedAt = createTimestamp()
 		},
 		decreaseQty(bondId: string) {
-			if (!this.bonds[bondId]) {
+			const activePortfolio = getActivePortfolio(this.storage)
+			if (!activePortfolio.bonds[bondId]) {
 				return
 			}
 
-			const nextQty = normalizePortfolioPosition(this.bonds[bondId], bondId).qty - 1
+			const nextQty = normalizePortfolioPosition(activePortfolio.bonds[bondId], bondId).qty - 1
 			if (nextQty < 1) {
 				this.dropBond(bondId)
 				return
 			}
 
-			this.bonds[bondId] = { uid: bondId, qty: nextQty }
+			activePortfolio.bonds[bondId] = { uid: bondId, qty: nextQty }
+			activePortfolio.updatedAt = createTimestamp()
 		},
 		setQty(bondId: string, qty: number) {
 			const nextQty = Math.max(0, Math.trunc(Number(qty)))
-
 			if (nextQty < 1) {
 				this.dropBond(bondId)
 				return
 			}
 
-			this.bonds[bondId] = { uid: bondId, qty: nextQty }
+			const activePortfolio = getActivePortfolio(this.storage)
+			activePortfolio.bonds[bondId] = { uid: bondId, qty: nextQty }
+			activePortfolio.updatedAt = createTimestamp()
 		},
 		getBondQty(bondId: string): number {
-			return this.bonds[bondId] ? normalizePortfolioPosition(this.bonds[bondId], bondId).qty : 0
+			const activePortfolio = getActivePortfolio(this.storage)
+			return activePortfolio.bonds[bondId] ? normalizePortfolioPosition(activePortfolio.bonds[bondId], bondId).qty : 0
 		},
 		dropBond(bondId: string) {
-			delete this.bonds[bondId]
+			const activePortfolio = getActivePortfolio(this.storage)
+			if (!activePortfolio.bonds[bondId]) {
+				return
+			}
+
+			delete activePortfolio.bonds[bondId]
+			activePortfolio.updatedAt = createTimestamp()
 		},
 		dropAllBonds() {
-			for (const bondId of Object.keys(this.bonds)) {
-				delete this.bonds[bondId]
+			const activePortfolio = getActivePortfolio(this.storage)
+			for (const bondId of Object.keys(activePortfolio.bonds)) {
+				delete activePortfolio.bonds[bondId]
 			}
+			activePortfolio.updatedAt = createTimestamp()
 		}
 	}
 })
 
-function normalizePortfolioPosition(position: LegacyPortfolioPosition | undefined, bondId: string): PortfolioPositionStored {
+export function createDefaultPortfolioState(): PortfolioStorageState {
+	const id = createPortfolioId()
+	return {
+		activePortfolioId: id,
+		portfolios: {
+			[id]: createEmptyPortfolio(id, DEFAULT_PORTFOLIO_NAME)
+		}
+	}
+}
+
+export function createEmptyPortfolio(id: string, name: string): SavedPortfolio {
+	const timestamp = createTimestamp()
+	return {
+		id,
+		name,
+		bonds: {},
+		createdAt: timestamp,
+		updatedAt: timestamp
+	}
+}
+
+export function createPortfolioId(): string {
+	return `portfolio-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+export function normalizePortfolioPosition(position: LegacyPortfolioPosition | undefined, bondId: string): PortfolioPositionStored {
 	const qty = Math.max(0, Math.trunc(Number(position?.qty ?? 0)))
 	const uid = typeof position?.uid === "string" && position.uid ? position.uid : bondId
 
 	return { uid, qty }
+}
+
+export function normalizePortfolioBonds(raw: unknown): Record<string, PortfolioPositionStored> {
+	if (!raw || typeof raw !== "object") {
+		return {}
+	}
+
+	const normalized: Record<string, PortfolioPositionStored> = {}
+	for (const bondId in raw as PortfolioBondsStore) {
+		const position = normalizePortfolioPosition((raw as PortfolioBondsStore)[bondId], bondId)
+		if (position.qty > 0) {
+			normalized[position.uid] = position
+		}
+	}
+
+	return normalized
+}
+
+export function migratePortfolioStorage(rawState: unknown, legacyBonds: unknown): {
+	state: PortfolioStorageState
+	consumeLegacy: boolean
+} {
+	const normalizedState = normalizePortfolioStorage(rawState)
+	if (normalizedState) {
+		return {
+			state: normalizedState,
+			consumeLegacy: false
+		}
+	}
+
+	const legacyPositions = normalizePortfolioBonds(legacyBonds)
+	if (Object.keys(legacyPositions).length < 1) {
+		return {
+			state: createDefaultPortfolioState(),
+			consumeLegacy: false
+		}
+	}
+
+	const id = createPortfolioId()
+	const portfolio = createEmptyPortfolio(id, DEFAULT_PORTFOLIO_NAME)
+	portfolio.bonds = legacyPositions
+	portfolio.updatedAt = createTimestamp()
+
+	return {
+		state: {
+			activePortfolioId: id,
+			portfolios: {
+				[id]: portfolio
+			}
+		},
+		consumeLegacy: true
+	}
+}
+
+export function normalizePortfolioStorage(rawState: unknown): PortfolioStorageState | null {
+	if (!rawState || typeof rawState !== "object") {
+		return null
+	}
+
+	const candidate = rawState as Partial<PortfolioStorageState>
+	if (!candidate.portfolios || typeof candidate.portfolios !== "object") {
+		return null
+	}
+
+	const normalizedPortfolios: Record<string, SavedPortfolio> = {}
+	for (const portfolioId in candidate.portfolios) {
+		const normalized = normalizeSavedPortfolio(candidate.portfolios[portfolioId], portfolioId)
+		if (normalized) {
+			normalizedPortfolios[portfolioId] = normalized
+		}
+	}
+
+	const portfolioIds = Object.keys(normalizedPortfolios)
+	if (portfolioIds.length < 1) {
+		return createDefaultPortfolioState()
+	}
+
+	const activePortfolioId =
+		typeof candidate.activePortfolioId === "string" && normalizedPortfolios[candidate.activePortfolioId]
+			? candidate.activePortfolioId
+			: portfolioIds[0]
+
+	return {
+		activePortfolioId,
+		portfolios: normalizedPortfolios
+	}
+}
+
+export function getActivePortfolio(state: PortfolioStorageState): SavedPortfolio {
+	const activePortfolio = state.portfolios[state.activePortfolioId]
+	if (activePortfolio) {
+		return activePortfolio
+	}
+
+	const fallbackId = Object.keys(state.portfolios)[0]
+	if (fallbackId) {
+		state.activePortfolioId = fallbackId
+		return state.portfolios[fallbackId]
+	}
+
+	const defaultState = createDefaultPortfolioState()
+	state.activePortfolioId = defaultState.activePortfolioId
+	state.portfolios = defaultState.portfolios
+	return state.portfolios[state.activePortfolioId]
+}
+
+function normalizeSavedPortfolio(rawPortfolio: unknown, fallbackId: string): SavedPortfolio | null {
+	if (!rawPortfolio || typeof rawPortfolio !== "object") {
+		return null
+	}
+
+	const portfolio = rawPortfolio as Partial<SavedPortfolio>
+	const id = typeof portfolio.id === "string" && portfolio.id ? portfolio.id : fallbackId
+	const defaultPortfolio = createEmptyPortfolio(id, DEFAULT_PORTFOLIO_NAME)
+
+	return {
+		id,
+		name: getPortfolioName(portfolio.name, 0, defaultPortfolio.name),
+		bonds: normalizePortfolioBonds(portfolio.bonds),
+		createdAt: normalizeTimestamp(portfolio.createdAt, defaultPortfolio.createdAt),
+		updatedAt: normalizeTimestamp(portfolio.updatedAt, defaultPortfolio.updatedAt)
+	}
+}
+
+function normalizeTimestamp(value: unknown, fallback: string): string {
+	if (typeof value !== "string") {
+		return fallback
+	}
+
+	const date = new Date(value)
+	return Number.isNaN(date.getTime()) ? fallback : date.toISOString()
+}
+
+function clonePortfolioBonds(bonds: Record<string, PortfolioPositionStored>): Record<string, PortfolioPositionStored> {
+	const clone: Record<string, PortfolioPositionStored> = {}
+	for (const bondId in bonds) {
+		clone[bondId] = { ...bonds[bondId] }
+	}
+	return clone
+}
+
+function getPortfolioName(name: unknown, index: number, fallback = ""): string {
+	if (typeof name === "string" && name.trim()) {
+		return name.trim().slice(0, 60)
+	}
+
+	if (fallback) {
+		return fallback
+	}
+
+	return index < 1 ? DEFAULT_PORTFOLIO_NAME : `Портфель ${index}`
+}
+
+function createTimestamp(): string {
+	return new Date().toISOString()
+}
+
+function readLegacyPortfolioStore(): unknown {
+	return readStorageValue(LEGACY_BONDS_STORAGE_KEY)
+}
+
+function readStorageValue(key: string): unknown {
+	if (!canUseLocalStorage()) {
+		return null
+	}
+
+	const raw = window.localStorage.getItem(key)
+	if (!raw) {
+		return null
+	}
+
+	try {
+		return JSON.parse(raw)
+	} catch {
+		return null
+	}
+}
+
+function canUseLocalStorage(): boolean {
+	return typeof window !== "undefined" && typeof window.localStorage !== "undefined"
 }
 
 export const portfolioStore = () => {

--- a/UI/src/views/PortfolioView.vue
+++ b/UI/src/views/PortfolioView.vue
@@ -6,8 +6,16 @@
 			class="card card-border min-w-0 h-[calc(100vh-var(--header-height)-1px)] bg-base-100"
 			id="table-view"
 		>
-			<div class="card-body h-full">
-				<portfolio-table :rows="portfolioRows" :loading="isFetchingTable" />
+			<div class="card-body flex h-full gap-4">
+				<div class="flex flex-wrap items-center justify-between gap-3 border-b border-base-300 pb-4">
+					<div>
+						<h1 class="text-lg font-semibold text-base-content">{{ activePortfolio.name }}</h1>
+						<p class="text-sm text-base-content/70">
+							{{ portfolioPositions.length }} позиций, {{ store.bondsQty }} шт.
+						</p>
+					</div>
+				</div>
+				<portfolio-table :rows="portfolioRows" :loading="isFetchingTable" class="min-h-0 flex-1" />
 			</div>
 		</div>
 
@@ -36,6 +44,7 @@ export default {
 		const isFetchingMetrics = ref(false)
 		const isFetchingTable = ref(false)
 		const store = portfolioStore()
+		const activePortfolio = computed(() => store.activePortfolio)
 		const portfolioPositions = computed<PortfolioPositionInput[]>(() => store.positions)
 		const portfolioMetrics = ref<PortfolioMetricsResponse | null>(null)
 		const portfolioRows = ref<PortfolioTableRow[]>([])
@@ -124,6 +133,9 @@ export default {
 		)
 
 		return {
+			store,
+			activePortfolio,
+			portfolioPositions,
 			portfolioRows,
 			portfolioMetrics,
 			isFetchingMetrics,

--- a/UI/tsconfig.app.json
+++ b/UI/tsconfig.app.json
@@ -13,7 +13,6 @@
   ],
   "compilerOptions": {
     "composite": true,
-    "baseUrl": ".",
     "allowJs": true,
     "paths": {
       "@/*": [


### PR DESCRIPTION
## Summary
- добавить browser-backed хранилище для нескольких сохранённых портфелей
- добавить переключатель портфелей и показывать активный сохранённый портфель в шапке и на странице портфеля
- расширить UI-тесты для нового хранилища портфелей и прогнать полный набор UI-тестов на этой ветке